### PR TITLE
feat: add logout command + fix tsconfig moduleResolution

### DIFF
--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,0 +1,18 @@
+import { Command } from "commander";
+import { clearConfig, getConfig } from "../config.js";
+import { success, warn } from "../utils/output.js";
+
+export function logoutCommand(program: Command): void {
+  program
+    .command("logout")
+    .description("Clear saved session credentials")
+    .action(() => {
+      const config = getConfig();
+      if (!config) {
+        warn("Not currently logged in.");
+        return;
+      }
+      clearConfig();
+      success("Logged out. Run `kuma login <url>` to authenticate again.");
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
 import { monitorsCommand } from "./commands/monitors.js";
 import { heartbeatCommand } from "./commands/heartbeat.js";
 import { statusPagesCommand } from "./commands/status-pages.js";
@@ -20,6 +21,7 @@ ${chalk.dim("Examples:")}
   ${chalk.cyan("kuma monitors list")}
   ${chalk.cyan("kuma monitors add --name \"My API\" --type http --url https://api.example.com")}
   ${chalk.cyan("kuma heartbeat 1")}
+  ${chalk.cyan("kuma logout")}
 
 ${chalk.dim("Config stored at:")} ${chalk.yellow(getConfigPath())}
 `
@@ -45,6 +47,7 @@ program
 
 // Register all commands
 loginCommand(program);
+logoutCommand(program);
 monitorsCommand(program);
 heartbeatCommand(program);
 statusPagesCommand(program);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## What

- Adds `kuma logout` command that clears the saved session from config
- Fixes `tsconfig.json` so `tsc --noEmit` passes (conf v15 is ESM-only, needs `moduleResolution: bundler`)

## Why

`kuma logout` is a fundamental UX missing piece — users need to be able to switch instances or clear credentials. Without it, they'd have to manually delete the config file.

The tsconfig fix is needed because CI typecheck was failing on the scaffolded config.

## Changes

- `src/commands/logout.ts` — new command: clears config, warns if not logged in
- `src/index.ts` — register logoutCommand + add to help examples
- `tsconfig.json` — `module: ESNext`, `moduleResolution: bundler`

## Test

```bash
kuma logout           # when not logged in → warns
kuma login <url>      # logs in
kuma logout           # → ✅ Logged out
kuma status           # → Not logged in
```