### PR TITLE
feat: add monitors update command

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -114,6 +114,11 @@ export class KumaClient {
     }));
   }
 
+  async editMonitor(id: number, monitor: Partial<Monitor>): Promise<void> {
+    this.socket.emit("editMonitor", { ...monitor, id });
+    await this.waitFor("editMonitorResult");
+  }
+
   async deleteMonitor(id: number): Promise<void> {
     this.socket.emit("deleteMonitor", id);
     await this.waitFor("deleteMonitorResult");

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -160,6 +160,45 @@ export function monitorsCommand(program: Command): void {
       }
     );
 
+  // UPDATE
+  monitors
+    .command("update <id>")
+    .description("Update an existing monitor's settings")
+    .option("--name <name>", "New monitor name")
+    .option("--url <url>", "New URL or hostname")
+    .option("--interval <seconds>", "New check interval in seconds")
+    .action(
+      async (
+        id: string,
+        opts: { name?: string; url?: string; interval?: string }
+      ) => {
+        const config = getConfig();
+        if (!config) requireAuth();
+
+        const patch: Record<string, string | number> = {};
+        if (opts.name) patch.name = opts.name;
+        if (opts.url) patch.url = opts.url;
+        if (opts.interval) patch.interval = parseInt(opts.interval, 10);
+
+        if (Object.keys(patch).length === 0) {
+          error("No fields to update. Use --name, --url, or --interval.");
+          process.exit(1);
+        }
+
+        try {
+          const client = await createAuthenticatedClient(
+            config!.url,
+            config!.token
+          );
+          await client.editMonitor(parseInt(id, 10), patch);
+          client.disconnect();
+          success(`Monitor ${id} updated`);
+        } catch (err) {
+          handleError(err);
+        }
+      }
+    );
+
   // DELETE
   monitors
     .command("delete <id>")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## What

Adds `kuma monitors update <id>` command to edit existing monitor settings.

## Why

The scaffold had list/add/delete/pause/resume but no way to update an existing monitor (e.g., rename it, change its URL, or adjust the check interval). This is a common need — monitors get renamed, endpoints change URLs.

## Changes

- `src/client.ts` — adds `editMonitor(id, patch)` method (emits `editMonitor` socket event)
- `src/commands/monitors.ts` — adds `monitors update <id>` subcommand with `--name`, `--url`, `--interval` flags; validates that at least one field is specified
- `tsconfig.json` — carries fix for `moduleResolution: bundler` (tsc typecheck was broken)

## Usage

```bash
kuma monitors update 42 --name "New Name"
kuma monitors update 42 --url https://new-url.com --interval 30
```

## Test

```bash
# Error if no flags given
kuma monitors update 1
# → ❌ No fields to update. Use --name, --url, or --interval.

# Happy path (requires live Kuma instance)
kuma monitors update 1 --name "Renamed Monitor"
# → ✅ Monitor 1 updated
```