### PR TITLE
ci: add build + typecheck GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    name: Build & Typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify binary
+        run: node dist/index.js --version

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## What

Adds a CI workflow that validates every PR and push to main.

## Why

The repo had AI review agents (pr-review.yml) but no CI to verify the code actually builds and typechecks. This means broken code could land in main undetected.

## Changes

- `.github/workflows/ci.yml` — runs on push/PR: install → typecheck → build → verify binary
- `tsconfig.json` — fix `moduleResolution: bundler` so tsc typecheck passes (conf v15 is ESM-only)

## CI Steps

1. `npm ci` — clean install
2. `npm run typecheck` — tsc --noEmit
3. `npm run build` — tsup compile
4. `node dist/index.js --version` — smoke test the binary