### PR TITLE
fix: resolve BUG-01 through BUG-04 (Socket.IO callback API, required fields, silent failures)

### DIFF
--- a/openspec/changes/kuma-cli-init/design.md
+++ b/openspec/changes/kuma-cli-init/design.md
@@ -81,8 +81,8 @@ kuma-cli/
 - Emits `getStatusPageList`
 - Renders table: ID | Name | Slug | URL
 
-#### `kuma heartbeat <slug>`
-- Emits `getHeartbeatList` for the given monitor slug
+#### `kuma heartbeat <monitor-id>`
+- Emits `getHeartbeatList` for the given monitor ID (integer, not slug — Kuma API uses integer IDs)
 - Renders last 20 heartbeats: Time | Status | Latency | Message
 
 ## Error Handling

--- a/src/client.ts
+++ b/src/client.ts
@@ -55,6 +55,10 @@ export class KumaClient {
     });
   }
 
+  /**
+   * Wait for a server-pushed event (not a callback response).
+   * Used for events the server pushes after authentication (monitorList, etc.).
+   */
   private waitFor<T>(event: string, timeoutMs = 10000): Promise<T> {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -86,20 +90,36 @@ export class KumaClient {
     });
   }
 
+  // BUG-01 fix: use Socket.IO acknowledgement callbacks instead of waitFor()
   async login(username: string, password: string): Promise<LoginResult> {
-    this.socket.emit("login", { username, password });
-    const result = await this.waitFor<{
-      ok: boolean;
-      token?: string;
-      msg?: string;
-    }>("loginResult");
-    return result;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Login timeout")),
+        10000
+      );
+      this.socket.emit(
+        "login",
+        { username, password },
+        (result: LoginResult) => {
+          clearTimeout(timer);
+          resolve(result);
+        }
+      );
+    });
   }
 
+  // BUG-01 fix: loginByToken also uses callback pattern
   async loginByToken(token: string): Promise<boolean> {
-    this.socket.emit("loginByToken", token);
-    const result = await this.waitFor<{ ok: boolean }>("loginResult");
-    return result.ok;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Login timeout")),
+        10000
+      );
+      this.socket.emit("loginByToken", token, (result: { ok: boolean }) => {
+        clearTimeout(timer);
+        resolve(result.ok);
+      });
+    });
   }
 
   async getMonitorList(): Promise<Record<string, Monitor>> {
@@ -107,31 +127,126 @@ export class KumaClient {
     return this.waitFor<Record<string, Monitor>>("monitorList");
   }
 
+  // BUG-01 fix: addMonitor uses callback, not a separate event
+  // BUG-03 fix: include required fields accepted_statuscodes, maxretries, retryInterval
   async addMonitor(monitor: Partial<Monitor>): Promise<{ id: number }> {
-    this.socket.emit("add", monitor);
-    return this.waitFor<{ monitorID: number }>("monitorID").then((r) => ({
-      id: r.monitorID,
-    }));
+    const payload = {
+      accepted_statuscodes: ["200-299"],
+      maxretries: 1,
+      retryInterval: 60,
+      ...monitor,
+    };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Add monitor timeout")),
+        10000
+      );
+      this.socket.emit(
+        "add",
+        payload,
+        (result: { ok: boolean; monitorID?: number; msg?: string }) => {
+          clearTimeout(timer);
+          // BUG-04 pattern: check result.ok
+          if (!result.ok) {
+            reject(new Error(result.msg ?? "Failed to add monitor"));
+            return;
+          }
+          resolve({ id: result.monitorID! });
+        }
+      );
+    });
   }
 
+  // BUG-01 fix: editMonitor uses callback pattern (consistent with all other mutations)
+  // BUG-04 fix: check result.ok and throw on failure
   async editMonitor(id: number, monitor: Partial<Monitor>): Promise<void> {
-    this.socket.emit("editMonitor", { ...monitor, id });
-    await this.waitFor("editMonitorResult");
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Edit monitor timeout")),
+        10000
+      );
+      this.socket.emit(
+        "editMonitor",
+        { ...monitor, id },
+        (result: { ok: boolean; msg?: string }) => {
+          clearTimeout(timer);
+          if (!result.ok) {
+            reject(new Error(result.msg ?? "Operation failed"));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
   }
 
+  // BUG-01 fix: deleteMonitor uses callback
+  // BUG-04 fix: check result.ok and throw on failure
   async deleteMonitor(id: number): Promise<void> {
-    this.socket.emit("deleteMonitor", id);
-    await this.waitFor("deleteMonitorResult");
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Delete monitor timeout")),
+        10000
+      );
+      this.socket.emit(
+        "deleteMonitor",
+        id,
+        (result: { ok: boolean; msg?: string }) => {
+          clearTimeout(timer);
+          if (!result.ok) {
+            reject(new Error(result.msg ?? "Operation failed"));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
   }
 
+  // BUG-01 fix: pauseMonitor uses callback
+  // BUG-04 fix: check result.ok and throw on failure
   async pauseMonitor(id: number): Promise<void> {
-    this.socket.emit("pauseMonitor", id);
-    await this.waitFor("pauseMonitorResult");
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Pause monitor timeout")),
+        10000
+      );
+      this.socket.emit(
+        "pauseMonitor",
+        id,
+        (result: { ok: boolean; msg?: string }) => {
+          clearTimeout(timer);
+          if (!result.ok) {
+            reject(new Error(result.msg ?? "Operation failed"));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
   }
 
+  // BUG-01 fix: resumeMonitor uses callback
+  // BUG-04 fix: check result.ok and throw on failure
   async resumeMonitor(id: number): Promise<void> {
-    this.socket.emit("resumeMonitor", id);
-    await this.waitFor("resumeMonitorResult");
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Resume monitor timeout")),
+        10000
+      );
+      this.socket.emit(
+        "resumeMonitor",
+        id,
+        (result: { ok: boolean; msg?: string }) => {
+          clearTimeout(timer);
+          if (!result.ok) {
+            reject(new Error(result.msg ?? "Operation failed"));
+            return;
+          }
+          resolve();
+        }
+      );
+    });
   }
 
   async getHeartbeatList(


### PR DESCRIPTION
## Summary

Fixes all 4 blockers identified in Jawad's QA report (`initial-scaffold-qa.md`).

---

## BUG-01 🔴 (Critical) — Socket.IO callback pattern

`client.ts` was using `waitFor(eventName)` to await responses, but the Kuma Socket.IO API uses **acknowledgement callbacks**. Every authenticated command was hanging for 10 seconds then timing out.

**Fixed:** Rewrote `login`, `loginByToken`, `addMonitor`, `deleteMonitor`, `pauseMonitor`, and `resumeMonitor` to use the correct callback pattern:

```ts
async login(username, password) {
  return new Promise((resolve, reject) => {
    const timer = setTimeout(() => reject(new Error("Login timeout")), 10000);
    this.socket.emit("login", { username, password }, (result) => {
      clearTimeout(timer);
      resolve(result);
    });
  });
}
```

Note: `getMonitorList`, `getHeartbeatList`, `getStatusPageList` remain event-based (`waitFor`) as the server pushes those after auth.

---

## BUG-02 — Spec mismatch: `heartbeat <slug>` → `heartbeat <monitor-id>`

The design spec said `kuma heartbeat <slug>` but the Kuma API takes an integer ID. The implementation was correct; the spec was wrong.

**Fixed:** Updated `openspec/changes/kuma-cli-init/design.md` to document `<monitor-id>` with a note that Kuma uses integer IDs.

---

## BUG-03 🔴 — `addMonitor` missing required Kuma fields

Kuma's `bean.validate()` requires `accepted_statuscodes`, `maxretries`, and `retryInterval`. Without them, every `monitors add` call failed server-side.

**Fixed:** `addMonitor` now spreads defaults before the caller's payload:

```ts
const payload = {
  accepted_statuscodes: ["200-299"],
  maxretries: 1,
  retryInterval: 60,
  ...monitor,
};
```

---

## BUG-04 🔴 — Silent failures on delete/pause/resume

The server returns `{ ok: false, msg: "..." }` on errors. The old code ignored this entirely, printing `✅ Monitor 9999 deleted` even when the monitor didn't exist.

**Fixed:** All three operations now check `result.ok` and throw with the server message:

```ts
if (!result.ok) {
  reject(new Error(result.msg ?? "Operation failed"));
  return;
}
```

---

## Testing

- `npm run build` passes ✅
- All 4 blockers addressed per QA report

## Out of Scope (tracked separately)

- ISSUE-05: tsconfig moduleResolution — tsup build works fine; `tsc --noEmit` failure is pre-existing
- ISSUE-06: status exit code
- ISSUE-07: non-TTY prompt handling