### PR TITLE
fix: add prepare script for npm install from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Problem

When installing via `npm install -g github:BlackAsteroid/kuma-cli`, the `kuma` command was not found after install. This happens because npm runs the `prepare` lifecycle hook during git installs — **not** `prepublishOnly`.

Since `dist/` is in `.gitignore` and no `prepare` script existed, the TypeScript source was never compiled and the `kuma` binary at `./dist/index.js` was missing.

## Fix

Add a `prepare` script that runs the build:

```json
"prepare": "npm run build"
```

This is a one-liner change. When npm installs from GitHub:
1. It installs all deps including `devDependencies` (`tsup`, `typescript`)
2. It runs `prepare` → `npm run build` → `tsup`
3. `dist/` is generated
4. `kuma` binary works ✅

## Notes

- `prepublishOnly` is kept for npm registry publishes (it also runs the build)
- No changes to devDependencies needed — npm installs them automatically during git installs
- No changes to `.gitignore` needed — the `prepare` script handles the build at install time