### PR TITLE
fix: monitors list shows real UP/DOWN status, uptime and ping

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27643,8 +27643,46 @@ var KumaClient = class {
     });
   }
   async getMonitorList() {
-    this.socket.emit("getMonitorList");
-    return this.waitFor("monitorList");
+    return new Promise((resolve) => {
+      const monitors = {};
+      const heartbeats = {};
+      const uptimes = {};
+      let monitorListReceived = false;
+      const mergeAndResolve = () => {
+        for (const [idStr, monitor] of Object.entries(monitors)) {
+          const id = Number(idStr);
+          const hb = heartbeats[id];
+          if (hb) monitor.heartbeat = hb;
+          const up24 = uptimes[`${id}_24`];
+          if (up24 !== void 0) monitor.uptime = up24;
+        }
+        resolve(monitors);
+      };
+      const safetyTimer = setTimeout(() => mergeAndResolve(), 3e3);
+      this.socket.on(
+        "heartbeatList",
+        (monitorId, data) => {
+          if (Array.isArray(data) && data.length > 0) {
+            heartbeats[monitorId] = data[data.length - 1];
+          }
+        }
+      );
+      this.socket.on(
+        "uptime",
+        (monitorId, period, value2) => {
+          uptimes[`${monitorId}_${period}`] = value2;
+        }
+      );
+      this.socket.emit(
+        "getMonitorList",
+        (data) => {
+          Object.assign(monitors, data);
+          monitorListReceived = true;
+          clearTimeout(safetyTimer);
+          setTimeout(() => mergeAndResolve(), 1500);
+        }
+      );
+    });
   }
   // BUG-01 fix: addMonitor uses callback, not a separate event
   // BUG-03 fix: include required fields accepted_statuscodes, maxretries, retryInterval
@@ -29981,54 +30019,86 @@ var MONITOR_TYPES = [
 ];
 function monitorsCommand(program3) {
   const monitors = program3.command("monitors").description("Manage monitors");
-  monitors.command("list").description("List all monitors").option("--json", "Output raw JSON").action(async (opts) => {
-    const config = getConfig();
-    if (!config) requireAuth();
-    try {
-      const client = await createAuthenticatedClient(
-        config.url,
-        config.token
-      );
-      const monitorMap = await client.getMonitorList();
-      client.disconnect();
-      const list = Object.values(monitorMap);
-      if (opts.json) {
-        console.log(JSON.stringify(list, null, 2));
-        return;
-      }
-      if (list.length === 0) {
-        console.log("No monitors found.");
-        return;
-      }
-      const table = createTable([
-        "ID",
-        "Name",
-        "Type",
-        "URL / Host",
-        "Status",
-        "Uptime 24h",
-        "Ping"
-      ]);
-      list.forEach((m) => {
-        const target = m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "\u2014");
-        const status = m.heartbeat ? statusLabel(m.heartbeat.status) : m.active ? statusLabel(2) : "\u23F8 Paused";
-        table.push([
-          String(m.id),
-          m.name,
-          m.type,
-          target,
-          status,
-          formatUptime(m.uptime),
-          formatPing(m.heartbeat?.ping)
+  monitors.command("list").description("List all monitors").option("--json", "Output raw JSON").option(
+    "--status <status>",
+    "Filter by status: up, down, pending, maintenance"
+  ).option("--tag <tag>", "Filter by tag name").action(
+    async (opts) => {
+      const config = getConfig();
+      if (!config) requireAuth();
+      const STATUS_MAP = {
+        down: 0,
+        up: 1,
+        pending: 2,
+        maintenance: 3
+      };
+      try {
+        const client = await createAuthenticatedClient(
+          config.url,
+          config.token
+        );
+        const monitorMap = await client.getMonitorList();
+        client.disconnect();
+        let list = Object.values(monitorMap);
+        if (opts.status) {
+          const statusKey = opts.status.toLowerCase();
+          if (!(statusKey in STATUS_MAP)) {
+            error(
+              `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance`
+            );
+            process.exit(1);
+          }
+          const statusNum = STATUS_MAP[statusKey];
+          list = list.filter((m) => {
+            if (m.heartbeat) return m.heartbeat.status === statusNum;
+            if (statusNum === 2) return m.active && !m.heartbeat;
+            return false;
+          });
+        }
+        if (opts.tag) {
+          const tagName = opts.tag.toLowerCase();
+          list = list.filter(
+            (m) => Array.isArray(m.tags) && m.tags.some((t) => t.name.toLowerCase() === tagName)
+          );
+        }
+        if (opts.json) {
+          console.log(JSON.stringify(list, null, 2));
+          return;
+        }
+        if (list.length === 0) {
+          console.log("No monitors found matching the given filters.");
+          return;
+        }
+        const table = createTable([
+          "ID",
+          "Name",
+          "Type",
+          "URL / Host",
+          "Status",
+          "Uptime 24h",
+          "Ping"
         ]);
-      });
-      console.log(table.toString());
-      console.log(`
+        list.forEach((m) => {
+          const target = m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "\u2014");
+          const status = m.heartbeat ? statusLabel(m.heartbeat.status) : m.active ? statusLabel(2) : "\u23F8 Paused";
+          table.push([
+            String(m.id),
+            m.name,
+            m.type,
+            target,
+            status,
+            formatUptime(m.uptime),
+            formatPing(m.heartbeat?.ping)
+          ]);
+        });
+        console.log(table.toString());
+        console.log(`
 ${list.length} monitor(s) total`);
-    } catch (err) {
-      handleError(err);
+      } catch (err) {
+        handleError(err);
+      }
     }
-  });
+  );
   monitors.command("add").description("Add a new monitor").option("--name <name>", "Monitor name").option("--type <type>", "Monitor type (http, tcp, ping, ...)").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds", "60").action(
     async (opts) => {
       const config = getConfig();

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,6 +6,12 @@ export interface LoginResult {
   msg?: string;
 }
 
+export interface MonitorTag {
+  id: number;
+  name: string;
+  color: string;
+}
+
 export interface Monitor {
   id: number;
   name: string;
@@ -16,6 +22,7 @@ export interface Monitor {
   interval: number;
   active: boolean;
   uptime?: number;
+  tags?: MonitorTag[];
   heartbeat?: {
     status: number;
     time: string;
@@ -123,8 +130,57 @@ export class KumaClient {
   }
 
   async getMonitorList(): Promise<Record<string, Monitor>> {
-    this.socket.emit("getMonitorList");
-    return this.waitFor<Record<string, Monitor>>("monitorList");
+    return new Promise((resolve) => {
+      const monitors: Record<string, Monitor> = {};
+      const heartbeats: Record<number, Heartbeat> = {};
+      const uptimes: Record<string, number> = {};
+      let monitorListReceived = false;
+
+      const mergeAndResolve = () => {
+        // Merge latest heartbeat + uptime into each monitor
+        for (const [idStr, monitor] of Object.entries(monitors)) {
+          const id = Number(idStr);
+          const hb = heartbeats[id];
+          if (hb) monitor.heartbeat = hb;
+          const up24 = uptimes[`${id}_24`];
+          if (up24 !== undefined) monitor.uptime = up24;
+        }
+        resolve(monitors);
+      };
+
+      // Safety valve — resolve after 3s regardless
+      const safetyTimer = setTimeout(() => mergeAndResolve(), 3000);
+
+      // Kuma pushes heartbeatList per monitor after auth: (monitorId, data[])
+      this.socket.on(
+        "heartbeatList",
+        (monitorId: number, data: Heartbeat[]) => {
+          if (Array.isArray(data) && data.length > 0) {
+            heartbeats[monitorId] = data[data.length - 1];
+          }
+        }
+      );
+
+      // Kuma pushes uptime per monitor after auth: (monitorId, period, value)
+      this.socket.on(
+        "uptime",
+        (monitorId: number, period: string, value: number) => {
+          uptimes[`${monitorId}_${period}`] = value;
+        }
+      );
+
+      // Request the monitor list via callback
+      this.socket.emit(
+        "getMonitorList",
+        (data: Record<string, Monitor>) => {
+          Object.assign(monitors, data);
+          monitorListReceived = true;
+          clearTimeout(safetyTimer);
+          // Give Kuma 1.5 s to push heartbeatList/uptime for all monitors
+          setTimeout(() => mergeAndResolve(), 1500);
+        }
+      );
+    });
   }
 
   // BUG-01 fix: addMonitor uses callback, not a separate event

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -38,64 +38,108 @@ export function monitorsCommand(program: Command): void {
     .command("list")
     .description("List all monitors")
     .option("--json", "Output raw JSON")
-    .action(async (opts: { json?: boolean }) => {
-      const config = getConfig();
-      if (!config) requireAuth();
+    .option(
+      "--status <status>",
+      "Filter by status: up, down, pending, maintenance"
+    )
+    .option("--tag <tag>", "Filter by tag name")
+    .action(
+      async (opts: { json?: boolean; status?: string; tag?: string }) => {
+        const config = getConfig();
+        if (!config) requireAuth();
 
-      try {
-        const client = await createAuthenticatedClient(
-          config!.url,
-          config!.token
-        );
-        const monitorMap = await client.getMonitorList();
-        client.disconnect();
+        // Map human-readable status strings to numeric values
+        const STATUS_MAP: Record<string, number> = {
+          down: 0,
+          up: 1,
+          pending: 2,
+          maintenance: 3,
+        };
 
-        const list = Object.values(monitorMap);
+        try {
+          const client = await createAuthenticatedClient(
+            config!.url,
+            config!.token
+          );
+          const monitorMap = await client.getMonitorList();
+          client.disconnect();
 
-        if (opts.json) {
-          console.log(JSON.stringify(list, null, 2));
-          return;
-        }
+          let list = Object.values(monitorMap);
 
-        if (list.length === 0) {
-          console.log("No monitors found.");
-          return;
-        }
+          // Apply --status filter
+          if (opts.status) {
+            const statusKey = opts.status.toLowerCase();
+            if (!(statusKey in STATUS_MAP)) {
+              error(
+                `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance`
+              );
+              process.exit(1);
+            }
+            const statusNum = STATUS_MAP[statusKey];
+            list = list.filter((m: Monitor) => {
+              if (m.heartbeat) return m.heartbeat.status === statusNum;
+              // For monitors with no heartbeat yet, match "pending" (2)
+              if (statusNum === 2) return m.active && !m.heartbeat;
+              return false;
+            });
+          }
 
-        const table = createTable([
-          "ID",
-          "Name",
-          "Type",
-          "URL / Host",
-          "Status",
-          "Uptime 24h",
-          "Ping",
-        ]);
+          // Apply --tag filter
+          if (opts.tag) {
+            const tagName = opts.tag.toLowerCase();
+            list = list.filter(
+              (m: Monitor) =>
+                Array.isArray(m.tags) &&
+                m.tags.some((t) => t.name.toLowerCase() === tagName)
+            );
+          }
 
-        list.forEach((m: Monitor) => {
-          const target = m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "—");
-          const status = m.heartbeat
-            ? statusLabel(m.heartbeat.status)
-            : m.active
-            ? statusLabel(2)
-            : "⏸ Paused";
-          table.push([
-            String(m.id),
-            m.name,
-            m.type,
-            target,
-            status,
-            formatUptime(m.uptime),
-            formatPing(m.heartbeat?.ping),
+          if (opts.json) {
+            console.log(JSON.stringify(list, null, 2));
+            return;
+          }
+
+          if (list.length === 0) {
+            console.log("No monitors found matching the given filters.");
+            return;
+          }
+
+          const table = createTable([
+            "ID",
+            "Name",
+            "Type",
+            "URL / Host",
+            "Status",
+            "Uptime 24h",
+            "Ping",
           ]);
-        });
 
-        console.log(table.toString());
-        console.log(`\n${list.length} monitor(s) total`);
-      } catch (err) {
-        handleError(err);
+          list.forEach((m: Monitor) => {
+            const target =
+              m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "—");
+            const status = m.heartbeat
+              ? statusLabel(m.heartbeat.status)
+              : m.active
+              ? statusLabel(2)
+              : "⏸ Paused";
+            table.push([
+              String(m.id),
+              m.name,
+              m.type,
+              target,
+              status,
+              formatUptime(m.uptime),
+              formatPing(m.heartbeat?.ping),
+            ]);
+          });
+
+          console.log(table.toString());
+          console.log(`\n${list.length} monitor(s) total`);
+        } catch (err) {
+          handleError(err);
+        }
       }
-    });
+    );
 
   // ADD
   monitors


### PR DESCRIPTION
## Problem

`kuma monitors list` always showed `PENDING` status and `—` for uptime/ping.

## Root Cause

After `loginByToken`, Uptime Kuma automatically pushes `heartbeatList` and `uptime` events for every monitor. The old `getMonitorList()` was using `emit + waitFor("monitorList")` which resolved immediately on the `monitorList` event — but then the client disconnected before the `heartbeatList`/`uptime` push events had a chance to arrive.

## Fix

Rewrote `getMonitorList()` to:
1. Register listeners for `heartbeatList` and `uptime` events **before** emitting `getMonitorList`
2. Use the callback pattern (not a push event) to receive the monitor list
3. After getting the monitor list, wait **1.5 s** for Kuma to push heartbeat/uptime data for all monitors
4. Merge heartbeat + uptime into each monitor before resolving
5. A **3 s safety timer** ensures the promise always resolves even if Kuma sends no heartbeat events

## Also included
- `kuma monitors list --status <up|down|pending|maintenance>` — filter by status
- `kuma monitors list --tag <name>` — filter by tag

## Testing
Build passes: `npm run build` ✅
TypeScript typecheck: clean ✅