### PR TITLE
feat: add 'monitors down' subcommand and 'kuma down' alias

### DIFF
--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -320,4 +320,133 @@ export function monitorsCommand(program: Command): void {
         handleError(err);
       }
     });
+
+  // DOWN — shortcut for monitors with status 0 (DOWN)
+  monitors
+    .command("down")
+    .description("Show only monitors that are currently DOWN")
+    .option("--json", "Output raw JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const config = getConfig();
+      if (!config) requireAuth();
+
+      try {
+        const client = await createAuthenticatedClient(
+          config!.url,
+          config!.token
+        );
+        const monitorMap = await client.getMonitorList();
+        client.disconnect();
+
+        const list = Object.values(monitorMap).filter(
+          (m: Monitor) => m.heartbeat?.status === 0
+        );
+
+        if (opts.json) {
+          console.log(JSON.stringify(list, null, 2));
+          return;
+        }
+
+        if (list.length === 0) {
+          console.log("✅ All monitors are UP");
+          return;
+        }
+
+        const table = createTable([
+          "ID",
+          "Name",
+          "Type",
+          "URL / Host",
+          "Status",
+          "Uptime 24h",
+          "Ping",
+        ]);
+
+        list.forEach((m: Monitor) => {
+          const target =
+            m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "—");
+          table.push([
+            String(m.id),
+            m.name,
+            m.type,
+            target,
+            statusLabel(0),
+            formatUptime(m.uptime),
+            formatPing(m.heartbeat?.ping),
+          ]);
+        });
+
+        console.log(table.toString());
+        console.log(`\n${list.length} monitor(s) DOWN`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
+}
+
+/**
+ * Register `kuma down` as a top-level alias for `kuma monitors down`.
+ * Called from src/index.ts after monitorsCommand().
+ */
+export function downAliasCommand(program: Command): void {
+  program
+    .command("down")
+    .description("Show only monitors that are currently DOWN (alias for: monitors down)")
+    .option("--json", "Output raw JSON")
+    .action(async (opts: { json?: boolean }) => {
+      const config = getConfig();
+      if (!config) requireAuth();
+
+      try {
+        const client = await createAuthenticatedClient(
+          config!.url,
+          config!.token
+        );
+        const monitorMap = await client.getMonitorList();
+        client.disconnect();
+
+        const list = Object.values(monitorMap).filter(
+          (m: Monitor) => m.heartbeat?.status === 0
+        );
+
+        if (opts.json) {
+          console.log(JSON.stringify(list, null, 2));
+          return;
+        }
+
+        if (list.length === 0) {
+          console.log("✅ All monitors are UP");
+          return;
+        }
+
+        const table = createTable([
+          "ID",
+          "Name",
+          "Type",
+          "URL / Host",
+          "Status",
+          "Uptime 24h",
+          "Ping",
+        ]);
+
+        list.forEach((m: Monitor) => {
+          const target =
+            m.url ?? (m.hostname ? `${m.hostname}:${m.port}` : "—");
+          table.push([
+            String(m.id),
+            m.name,
+            m.type,
+            target,
+            statusLabel(0),
+            formatUptime(m.uptime),
+            formatPing(m.heartbeat?.ping),
+          ]);
+        });
+
+        console.log(table.toString());
+        console.log(`\n${list.length} monitor(s) DOWN`);
+      } catch (err) {
+        handleError(err);
+      }
+    });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
-import { monitorsCommand } from "./commands/monitors.js";
+import { monitorsCommand, downAliasCommand } from "./commands/monitors.js";
 import { heartbeatCommand } from "./commands/heartbeat.js";
 import { statusPagesCommand } from "./commands/status-pages.js";
 import { getConfig, getConfigPath } from "./config.js";
@@ -51,5 +51,6 @@ logoutCommand(program);
 monitorsCommand(program);
 heartbeatCommand(program);
 statusPagesCommand(program);
+downAliasCommand(program); // `kuma down` → shortcut for `kuma monitors down`
 
 program.parse(process.argv);


### PR DESCRIPTION
## Summary

Adds a fast, dedicated command to show only DOWN monitors — the most common on-call use case.

## New Commands

```bash
kuma monitors down      # shows only monitors with status=0 (DOWN)
kuma down               # top-level alias → same as 'monitors down'
```

## Output

When monitors are down:
```
╭────┬─────────────────────────────┬──────┬─────────────────────────────────────┬────────┬────────────┬──────╮
│ ID │ Name                        │ Type │ URL / Host                          │ Status │ Uptime 24h │ Ping │
├────┼─────────────────────────────┼──────┼─────────────────────────────────────┼────────┼────────────┼──────┤
│ 22 │ portal.blackasteroid.com.ar │ http │ https://portal.blackasteroid.com.ar │ ● DOWN │ 0.0%       │ —    │
╰────┴─────────────────────────────┴──────┴─────────────────────────────────────┴────────┴────────────┴──────╯

1 monitor(s) DOWN
```

When all monitors are healthy:
```
✅ All monitors are UP
```

## Flags

- `--json`: Output raw JSON array (for scripting/alerting pipelines)

## Implementation

- `src/commands/monitors.ts`: New `monitors down` subcommand + exported `downAliasCommand()`
- `src/index.ts`: Register `downAliasCommand` as top-level `kuma down`
- `dist/index.js`: Rebuilt

## Testing (on aang)

```bash
# Shows portal.blackasteroid.com.ar as currently DOWN
kuma monitors down
kuma down

# JSON output
kuma down --json
```

## Base branch

Based on `feat/monitors-filter-tags` (PR #8) — requires the heartbeat cache fix for real status data.