### PR TITLE
feat: monitors update — full object fetch + --active/--no-active flags

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27647,8 +27647,9 @@ var KumaClient = class {
       const monitors = {};
       const heartbeats = {};
       const uptimes = {};
-      let monitorListReceived = false;
       const mergeAndResolve = () => {
+        this.socket.off("heartbeatList");
+        this.socket.off("uptime");
         for (const [idStr, monitor] of Object.entries(monitors)) {
           const id = Number(idStr);
           const hb = heartbeats[id];
@@ -27658,7 +27659,7 @@ var KumaClient = class {
         }
         resolve(monitors);
       };
-      const safetyTimer = setTimeout(() => mergeAndResolve(), 3e3);
+      const safetyTimer = setTimeout(() => mergeAndResolve(), 5e3);
       this.socket.on(
         "heartbeatList",
         (monitorId, data) => {
@@ -27673,15 +27674,16 @@ var KumaClient = class {
           uptimes[`${monitorId}_${period}`] = value2;
         }
       );
-      this.socket.emit(
-        "getMonitorList",
+      this.socket.once(
+        "monitorList",
         (data) => {
           Object.assign(monitors, data);
-          monitorListReceived = true;
           clearTimeout(safetyTimer);
           setTimeout(() => mergeAndResolve(), 1500);
         }
       );
+      this.socket.emit("getMonitorList", () => {
+      });
     });
   }
   // BUG-01 fix: addMonitor uses callback, not a separate event
@@ -30138,16 +30140,20 @@ ${list.length} monitor(s) total`);
       }
     }
   );
-  monitors.command("update <id>").description("Update an existing monitor's settings").option("--name <name>", "New monitor name").option("--url <url>", "New URL or hostname").option("--interval <seconds>", "New check interval in seconds").action(
+  monitors.command("update <id>").description("Update an existing monitor's settings").option("--name <name>", "New monitor name").option("--url <url>", "New URL or hostname").option("--interval <seconds>", "New check interval in seconds").option("--active", "Activate (resume) the monitor").option("--no-active", "Deactivate (pause) the monitor").action(
     async (id, opts) => {
       const config = getConfig();
       if (!config) requireAuth();
-      const patch = {};
-      if (opts.name) patch.name = opts.name;
-      if (opts.url) patch.url = opts.url;
-      if (opts.interval) patch.interval = parseInt(opts.interval, 10);
-      if (Object.keys(patch).length === 0) {
-        error("No fields to update. Use --name, --url, or --interval.");
+      const monitorId = parseInt(id, 10);
+      if (isNaN(monitorId)) {
+        error(`Invalid monitor ID: ${id}`);
+        process.exit(1);
+      }
+      const hasPatch = opts.name !== void 0 || opts.url !== void 0 || opts.interval !== void 0 || opts.active !== void 0;
+      if (!hasPatch) {
+        error(
+          "No fields to update. Use --name, --url, --interval, --active, or --no-active."
+        );
         process.exit(1);
       }
       try {
@@ -30155,9 +30161,45 @@ ${list.length} monitor(s) total`);
           config.url,
           config.token
         );
-        await client.editMonitor(parseInt(id, 10), patch);
+        const monitorMap = await client.getMonitorList();
+        const existing = monitorMap[String(monitorId)];
+        if (!existing) {
+          client.disconnect();
+          const ids = Object.keys(monitorMap).join(", ");
+          error(
+            `Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`
+          );
+          process.exit(1);
+        }
+        const changes = [];
+        const hasFieldChanges = opts.name !== void 0 || opts.url !== void 0 || opts.interval !== void 0;
+        if (hasFieldChanges) {
+          const updated = { ...existing };
+          if (opts.name !== void 0) {
+            updated.name = opts.name;
+            changes.push(`name \u2192 "${opts.name}"`);
+          }
+          if (opts.url !== void 0) {
+            updated.url = opts.url;
+            changes.push(`url \u2192 "${opts.url}"`);
+          }
+          if (opts.interval !== void 0) {
+            updated.interval = parseInt(opts.interval, 10);
+            changes.push(`interval \u2192 ${opts.interval}s`);
+          }
+          await client.editMonitor(monitorId, updated);
+        }
+        if (opts.active !== void 0) {
+          if (opts.active) {
+            await client.resumeMonitor(monitorId);
+            changes.push("activated");
+          } else {
+            await client.pauseMonitor(monitorId);
+            changes.push("deactivated");
+          }
+        }
         client.disconnect();
-        success(`Monitor ${id} updated`);
+        success(`Monitor ${monitorId} updated (${changes.join(", ")})`);
       } catch (err) {
         handleError(err);
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -134,9 +134,11 @@ export class KumaClient {
       const monitors: Record<string, Monitor> = {};
       const heartbeats: Record<number, Heartbeat> = {};
       const uptimes: Record<string, number> = {};
-      let monitorListReceived = false;
 
       const mergeAndResolve = () => {
+        // Clean up persistent listeners
+        this.socket.off("heartbeatList");
+        this.socket.off("uptime");
         // Merge latest heartbeat + uptime into each monitor
         for (const [idStr, monitor] of Object.entries(monitors)) {
           const id = Number(idStr);
@@ -148,10 +150,10 @@ export class KumaClient {
         resolve(monitors);
       };
 
-      // Safety valve — resolve after 3s regardless
-      const safetyTimer = setTimeout(() => mergeAndResolve(), 3000);
+      // Safety valve — resolve after 5s regardless
+      const safetyTimer = setTimeout(() => mergeAndResolve(), 5000);
 
-      // Kuma pushes heartbeatList per monitor after auth: (monitorId, data[])
+      // Kuma pushes heartbeatList per monitor: (monitorId, data[])
       this.socket.on(
         "heartbeatList",
         (monitorId: number, data: Heartbeat[]) => {
@@ -161,7 +163,7 @@ export class KumaClient {
         }
       );
 
-      // Kuma pushes uptime per monitor after auth: (monitorId, period, value)
+      // Kuma pushes uptime per monitor: (monitorId, period, value)
       this.socket.on(
         "uptime",
         (monitorId: number, period: string, value: number) => {
@@ -169,17 +171,22 @@ export class KumaClient {
         }
       );
 
-      // Request the monitor list via callback
-      this.socket.emit(
-        "getMonitorList",
+      // Kuma sends the full monitor map via "monitorList" push event
+      // (the getMonitorList callback only returns {ok: true})
+      this.socket.once(
+        "monitorList",
         (data: Record<string, Monitor>) => {
           Object.assign(monitors, data);
-          monitorListReceived = true;
           clearTimeout(safetyTimer);
           // Give Kuma 1.5 s to push heartbeatList/uptime for all monitors
           setTimeout(() => mergeAndResolve(), 1500);
         }
       );
+
+      // Emit getMonitorList to trigger the server to push the monitorList event
+      this.socket.emit("getMonitorList", () => {
+        // Callback returns {ok: true} — actual data comes via push event above
+      });
     });
   }
 

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -211,21 +211,38 @@ export function monitorsCommand(program: Command): void {
     .option("--name <name>", "New monitor name")
     .option("--url <url>", "New URL or hostname")
     .option("--interval <seconds>", "New check interval in seconds")
+    .option("--active", "Activate (resume) the monitor")
+    .option("--no-active", "Deactivate (pause) the monitor")
     .action(
       async (
         id: string,
-        opts: { name?: string; url?: string; interval?: string }
+        opts: {
+          name?: string;
+          url?: string;
+          interval?: string;
+          active?: boolean;
+        }
       ) => {
         const config = getConfig();
         if (!config) requireAuth();
 
-        const patch: Record<string, string | number> = {};
-        if (opts.name) patch.name = opts.name;
-        if (opts.url) patch.url = opts.url;
-        if (opts.interval) patch.interval = parseInt(opts.interval, 10);
+        const monitorId = parseInt(id, 10);
+        if (isNaN(monitorId)) {
+          error(`Invalid monitor ID: ${id}`);
+          process.exit(1);
+        }
 
-        if (Object.keys(patch).length === 0) {
-          error("No fields to update. Use --name, --url, or --interval.");
+        // Determine which fields were explicitly provided
+        const hasPatch =
+          opts.name !== undefined ||
+          opts.url !== undefined ||
+          opts.interval !== undefined ||
+          opts.active !== undefined;
+
+        if (!hasPatch) {
+          error(
+            "No fields to update. Use --name, --url, --interval, --active, or --no-active."
+          );
           process.exit(1);
         }
 
@@ -234,9 +251,61 @@ export function monitorsCommand(program: Command): void {
             config!.url,
             config!.token
           );
-          await client.editMonitor(parseInt(id, 10), patch);
+
+          // Fetch full monitor list so we can send the complete object back
+          // (Kuma's editMonitor requires all fields, not just the diff)
+          const monitorMap = await client.getMonitorList();
+          const existing = monitorMap[String(monitorId)];
+
+          if (!existing) {
+            client.disconnect();
+            const ids = Object.keys(monitorMap).join(", ");
+            error(
+              `Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`
+            );
+            process.exit(1);
+          }
+
+          // Build a human-readable summary of what changed
+          const changes: string[] = [];
+
+          // Apply field changes via editMonitor (name, url, interval)
+          const hasFieldChanges =
+            opts.name !== undefined ||
+            opts.url !== undefined ||
+            opts.interval !== undefined;
+
+          if (hasFieldChanges) {
+            const updated: Monitor = { ...existing };
+            if (opts.name !== undefined) {
+              updated.name = opts.name;
+              changes.push(`name → "${opts.name}"`);
+            }
+            if (opts.url !== undefined) {
+              updated.url = opts.url;
+              changes.push(`url → "${opts.url}"`);
+            }
+            if (opts.interval !== undefined) {
+              updated.interval = parseInt(opts.interval, 10);
+              changes.push(`interval → ${opts.interval}s`);
+            }
+            await client.editMonitor(monitorId, updated);
+          }
+
+          // Apply active/inactive via pauseMonitor / resumeMonitor
+          // (editMonitor ignores the active field — Kuma uses separate events)
+          if (opts.active !== undefined) {
+            if (opts.active) {
+              await client.resumeMonitor(monitorId);
+              changes.push("activated");
+            } else {
+              await client.pauseMonitor(monitorId);
+              changes.push("deactivated");
+            }
+          }
+
           client.disconnect();
-          success(`Monitor ${id} updated`);
+          success(`Monitor ${monitorId} updated (${changes.join(", ")})`);
         } catch (err) {
           handleError(err);
         }


### PR DESCRIPTION
## Summary

Improves the `kuma monitors update <id>` command with two fixes and new flags.

### Fixes

#### Fix: `getMonitorList` — use push event instead of callback
The Kuma Socket.IO API does **not** return monitor data via the `getMonitorList` callback. It only returns `{ok: true}`. The actual monitor map is pushed as a `monitorList` event after auth.

Previous implementation was calling `Object.assign(monitors, {ok:true})` → `monitors list` showed `[true]`.

Fixed: now listens for the `monitorList` push event (consistent with how Kuma's web UI works).

#### Fix: `monitors update` — send full monitor object to `editMonitor`
Kuma's `editMonitor` requires the complete monitor object, not just a diff. The previous implementation sent only the patched fields, which caused Kuma to reset unspecified fields to defaults.

Fixed: fetch the full monitor via `getMonitorList`, merge only the specified fields, then send the complete object.

### New Flags

| Flag | Description |
|------|-------------|
| `--active` | Activate (resume) the monitor |
| `--no-active` | Deactivate (pause) the monitor |

Note: `editMonitor` ignores the `active` field. Active state changes are handled via `resumeMonitor` / `pauseMonitor` events.

## Usage

```bash
kuma monitors update <id> [flags]
  --name <name>       Change monitor name
  --url <url>         Change URL or hostname
  --interval <secs>   Change check interval
  --active            Activate the monitor
  --no-active         Deactivate (pause) the monitor
```

## Examples

```bash
kuma monitors update 12 --name "My API" --interval 30
# ✅ Monitor 12 updated (name → "My API", interval → 30s)

kuma monitors update 12 --no-active
# ✅ Monitor 12 updated (deactivated)

kuma monitors update 12 --active
# ✅ Monitor 12 updated (activated)
```

## Testing

Tested on aang against real monitors on `kuma.blackasteroid.com.ar`:
- ✅ `--name` renames the monitor
- ✅ `--url` changes the URL
- ✅ `--interval` updates the check interval
- ✅ `--no-active` pauses the monitor (verified `active: false` via list)
- ✅ `--active` resumes the monitor (verified `active: true` via list)
- ✅ Multiple flags in one call
- ✅ Error on no flags provided
- ✅ Error on invalid monitor ID