### PR TITLE
feat: agent-compatible JSON mode (--json flag + KUMA_JSON env var)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -29932,25 +29932,65 @@ function formatPing(ping) {
 function formatDate(dateStr) {
   return new Date(dateStr).toLocaleString();
 }
+function isJsonMode(opts) {
+  if (opts?.json) return true;
+  const env3 = process.env["KUMA_JSON"];
+  return env3 === "1" || env3 === "true" || env3 === "yes";
+}
+function jsonOut(data) {
+  console.log(JSON.stringify({ ok: true, data }, null, 2));
+  process.exit(0);
+}
+function jsonError(message, code = 1) {
+  console.log(JSON.stringify({ ok: false, error: message, code }, null, 2));
+  process.exit(code);
+}
 
 // src/utils/errors.ts
-function handleError(err, exitCode = 1) {
-  if (err instanceof Error) {
-    error(err.message);
-  } else {
-    error(String(err));
+var EXIT_CODES = {
+  SUCCESS: 0,
+  GENERAL: 1,
+  CONNECTION: 2,
+  NOT_FOUND: 3,
+  AUTH: 4
+};
+function exitCodeFor(err) {
+  if (!(err instanceof Error)) return EXIT_CODES.GENERAL;
+  const msg = err.message.toLowerCase();
+  if (msg.includes("connection") || msg.includes("timeout") || msg.includes("refused")) {
+    return EXIT_CODES.CONNECTION;
   }
-  process.exit(exitCode);
+  if (msg.includes("not found") || msg.includes("not exist")) {
+    return EXIT_CODES.NOT_FOUND;
+  }
+  if (msg.includes("auth") || msg.includes("session expired") || msg.includes("login")) {
+    return EXIT_CODES.AUTH;
+  }
+  return EXIT_CODES.GENERAL;
 }
-function requireAuth() {
-  error("Not authenticated. Run: kuma login <url>");
-  process.exit(1);
+function handleError(err, opts) {
+  const message = err instanceof Error ? err.message : String(err);
+  const code = exitCodeFor(err);
+  if (isJsonMode(opts)) {
+    jsonError(message, code);
+  }
+  error(message);
+  process.exit(code);
+}
+function requireAuth(opts) {
+  const message = "Not authenticated. Run: kuma login <url>";
+  if (isJsonMode(opts)) {
+    jsonError(message, EXIT_CODES.AUTH);
+  }
+  error(message);
+  process.exit(EXIT_CODES.AUTH);
 }
 
 // src/commands/login.ts
 var { prompt } = import_enquirer.default;
 function loginCommand(program3) {
-  program3.command("login <url>").description("Authenticate with Uptime Kuma and save session").action(async (url2) => {
+  program3.command("login <url>").description("Authenticate with Uptime Kuma and save session").option("--json", "Output as JSON ({ ok, data })").action(async (url2, opts) => {
+    const json = isJsonMode(opts);
     try {
       const normalizedUrl = url2.replace(/\/$/, "");
       const answers = await prompt([
@@ -29971,26 +30011,40 @@ function loginCommand(program3) {
       const result = await client.login(username, password);
       client.disconnect();
       if (!result.ok || !result.token) {
-        error(result.msg ?? "Login failed");
+        const msg = result.msg ?? "Login failed";
+        if (json) {
+          jsonOut({ error: msg });
+        }
+        error(msg);
         process.exit(1);
       }
       saveConfig({ url: normalizedUrl, token: result.token });
+      if (json) {
+        jsonOut({ url: normalizedUrl, username });
+      }
       success(`Logged in as ${username} \u2192 ${normalizedUrl}`);
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
 }
 
 // src/commands/logout.ts
 function logoutCommand(program3) {
-  program3.command("logout").description("Clear saved session credentials").action(() => {
+  program3.command("logout").description("Clear saved session credentials").option("--json", "Output as JSON ({ ok, data })").action((opts) => {
+    const json = isJsonMode(opts);
     const config = getConfig();
     if (!config) {
+      if (json) {
+        jsonOut({ loggedOut: false, reason: "Not currently logged in" });
+      }
       warn("Not currently logged in.");
       return;
     }
     clearConfig();
+    if (json) {
+      jsonOut({ loggedOut: true });
+    }
     success("Logged out. Run `kuma login <url>` to authenticate again.");
   });
 }
@@ -30015,13 +30069,14 @@ var MONITOR_TYPES = [
 ];
 function monitorsCommand(program3) {
   const monitors = program3.command("monitors").description("Manage monitors");
-  monitors.command("list").description("List all monitors").option("--json", "Output raw JSON").option(
+  monitors.command("list").description("List all monitors").option("--json", "Output as JSON ({ ok, data })").option(
     "--status <status>",
     "Filter by status: up, down, pending, maintenance"
   ).option("--tag <tag>", "Filter by tag name").action(
     async (opts) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+      const json = isJsonMode(opts);
       const STATUS_MAP = {
         down: 0,
         up: 1,
@@ -30039,6 +30094,9 @@ function monitorsCommand(program3) {
         if (opts.status) {
           const statusKey = opts.status.toLowerCase();
           if (!(statusKey in STATUS_MAP)) {
+            if (json) {
+              jsonOut({ error: `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance` });
+            }
             error(
               `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance`
             );
@@ -30057,9 +30115,8 @@ function monitorsCommand(program3) {
             (m) => Array.isArray(m.tags) && m.tags.some((t) => t.name.toLowerCase() === tagName)
           );
         }
-        if (opts.json) {
-          console.log(JSON.stringify(list, null, 2));
-          return;
+        if (json) {
+          jsonOut(list);
         }
         if (list.length === 0) {
           console.log("No monitors found matching the given filters.");
@@ -30091,14 +30148,15 @@ function monitorsCommand(program3) {
         console.log(`
 ${list.length} monitor(s) total`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     }
   );
-  monitors.command("add").description("Add a new monitor").option("--name <name>", "Monitor name").option("--type <type>", "Monitor type (http, tcp, ping, ...)").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds", "60").action(
+  monitors.command("add").description("Add a new monitor").option("--name <name>", "Monitor name").option("--type <type>", "Monitor type (http, tcp, ping, ...)").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds", "60").option("--json", "Output as JSON ({ ok, data })").action(
     async (opts) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+      const json = isJsonMode(opts);
       try {
         const answers = await prompt2([
           ...!opts.name ? [{ type: "input", name: "name", message: "Monitor name:" }] : [],
@@ -30128,27 +30186,30 @@ ${list.length} monitor(s) total`);
         );
         const result = await client.addMonitor({ name, type, url: url2, interval });
         client.disconnect();
+        if (json) {
+          jsonOut({ id: result.id, name, type, url: url2, interval });
+        }
         success(`Monitor "${name}" created (ID: ${result.id})`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     }
   );
-  monitors.command("update <id>").description("Update an existing monitor's settings").option("--name <name>", "New monitor name").option("--url <url>", "New URL or hostname").option("--interval <seconds>", "New check interval in seconds").option("--active", "Activate (resume) the monitor").option("--no-active", "Deactivate (pause) the monitor").action(
+  monitors.command("update <id>").description("Update an existing monitor's settings").option("--name <name>", "New monitor name").option("--url <url>", "New URL or hostname").option("--interval <seconds>", "New check interval in seconds").option("--active", "Activate (resume) the monitor").option("--no-active", "Deactivate (pause) the monitor").option("--json", "Output as JSON ({ ok, data })").action(
     async (id, opts) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+      const json = isJsonMode(opts);
       const monitorId = parseInt(id, 10);
       if (isNaN(monitorId)) {
-        error(`Invalid monitor ID: ${id}`);
-        process.exit(1);
+        handleError(new Error(`Invalid monitor ID: ${id}`), opts);
       }
       const hasPatch = opts.name !== void 0 || opts.url !== void 0 || opts.interval !== void 0 || opts.active !== void 0;
       if (!hasPatch) {
-        error(
-          "No fields to update. Use --name, --url, --interval, --active, or --no-active."
+        handleError(
+          new Error("No fields to update. Use --name, --url, --interval, --active, or --no-active."),
+          opts
         );
-        process.exit(1);
       }
       try {
         const client = await createAuthenticatedClient(
@@ -30160,10 +30221,10 @@ ${list.length} monitor(s) total`);
         if (!existing) {
           client.disconnect();
           const ids = Object.keys(monitorMap).join(", ");
-          error(
-            `Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`
+          handleError(
+            new Error(`Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`),
+            opts
           );
-          process.exit(1);
         }
         const changes = [];
         const hasFieldChanges = opts.name !== void 0 || opts.url !== void 0 || opts.interval !== void 0;
@@ -30193,17 +30254,21 @@ ${list.length} monitor(s) total`);
           }
         }
         client.disconnect();
+        if (json) {
+          jsonOut({ id: monitorId, changes });
+        }
         success(`Monitor ${monitorId} updated (${changes.join(", ")})`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     }
   );
-  monitors.command("delete <id>").description("Delete a monitor").option("--force", "Skip confirmation").action(async (id, opts) => {
+  monitors.command("delete <id>").description("Delete a monitor").option("--force", "Skip confirmation").option("--json", "Output as JSON ({ ok, data })").action(async (id, opts) => {
     const config = getConfig();
-    if (!config) requireAuth();
+    if (!config) requireAuth(opts);
+    const json = isJsonMode(opts);
     try {
-      if (!opts.force) {
+      if (!opts.force && !json) {
         const { confirm } = await prompt2({
           type: "confirm",
           name: "confirm",
@@ -30221,14 +30286,18 @@ ${list.length} monitor(s) total`);
       );
       await client.deleteMonitor(parseInt(id, 10));
       client.disconnect();
+      if (json) {
+        jsonOut({ id: parseInt(id, 10), deleted: true });
+      }
       success(`Monitor ${id} deleted`);
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
-  monitors.command("pause <id>").description("Pause a monitor").action(async (id) => {
+  monitors.command("pause <id>").description("Pause a monitor").option("--json", "Output as JSON ({ ok, data })").action(async (id, opts) => {
     const config = getConfig();
-    if (!config) requireAuth();
+    if (!config) requireAuth(opts);
+    const json = isJsonMode(opts);
     try {
       const client = await createAuthenticatedClient(
         config.url,
@@ -30236,14 +30305,18 @@ ${list.length} monitor(s) total`);
       );
       await client.pauseMonitor(parseInt(id, 10));
       client.disconnect();
+      if (json) {
+        jsonOut({ id: parseInt(id, 10), paused: true });
+      }
       success(`Monitor ${id} paused`);
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
-  monitors.command("resume <id>").description("Resume a monitor").action(async (id) => {
+  monitors.command("resume <id>").description("Resume a monitor").option("--json", "Output as JSON ({ ok, data })").action(async (id, opts) => {
     const config = getConfig();
-    if (!config) requireAuth();
+    if (!config) requireAuth(opts);
+    const json = isJsonMode(opts);
     try {
       const client = await createAuthenticatedClient(
         config.url,
@@ -30251,18 +30324,22 @@ ${list.length} monitor(s) total`);
       );
       await client.resumeMonitor(parseInt(id, 10));
       client.disconnect();
+      if (json) {
+        jsonOut({ id: parseInt(id, 10), resumed: true });
+      }
       success(`Monitor ${id} resumed`);
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
 }
 
 // src/commands/heartbeat.ts
 function heartbeatCommand(program3) {
-  program3.command("heartbeat <monitor-id>").description("View recent heartbeats for a monitor").option("--limit <n>", "Number of heartbeats to show", "20").option("--json", "Output raw JSON").action(async (monitorId, opts) => {
+  program3.command("heartbeat <monitor-id>").description("View recent heartbeats for a monitor").option("--limit <n>", "Number of heartbeats to show", "20").option("--json", "Output as JSON ({ ok, data })").action(async (monitorId, opts) => {
     const config = getConfig();
-    if (!config) requireAuth();
+    if (!config) requireAuth(opts);
+    const json = isJsonMode(opts);
     try {
       const client = await createAuthenticatedClient(
         config.url,
@@ -30274,9 +30351,8 @@ function heartbeatCommand(program3) {
       client.disconnect();
       const limit = parseInt(opts.limit ?? "20", 10);
       const recent = heartbeats.slice(-limit).reverse();
-      if (opts.json) {
-        console.log(JSON.stringify(recent, null, 2));
-        return;
+      if (json) {
+        jsonOut(recent);
       }
       if (recent.length === 0) {
         console.log("No heartbeats found.");
@@ -30295,7 +30371,7 @@ function heartbeatCommand(program3) {
       console.log(`
 Showing last ${recent.length} heartbeat(s)`);
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
 }
@@ -30303,9 +30379,10 @@ Showing last ${recent.length} heartbeat(s)`);
 // src/commands/status-pages.ts
 function statusPagesCommand(program3) {
   const sp = program3.command("status-pages").description("Manage status pages");
-  sp.command("list").description("List all status pages").option("--json", "Output raw JSON").action(async (opts) => {
+  sp.command("list").description("List all status pages").option("--json", "Output as JSON ({ ok, data })").action(async (opts) => {
     const config = getConfig();
-    if (!config) requireAuth();
+    if (!config) requireAuth(opts);
+    const json = isJsonMode(opts);
     try {
       const client = await createAuthenticatedClient(
         config.url,
@@ -30314,9 +30391,8 @@ function statusPagesCommand(program3) {
       const pages = await client.getStatusPageList();
       client.disconnect();
       const list = Object.values(pages);
-      if (opts.json) {
-        console.log(JSON.stringify(list, null, 2));
-        return;
+      if (json) {
+        jsonOut(list);
       }
       if (list.length === 0) {
         console.log("No status pages found.");
@@ -30335,7 +30411,7 @@ function statusPagesCommand(program3) {
       });
       console.log(table.toString());
     } catch (err) {
-      handleError(err);
+      handleError(err, opts);
     }
   });
 }
@@ -30352,21 +30428,43 @@ ${source_default.dim("Examples:")}
   ${source_default.cyan("kuma heartbeat 1")}
   ${source_default.cyan("kuma logout")}
 
+${source_default.dim("JSON mode (any command):")}
+  ${source_default.cyan("kuma monitors list --json")}
+  ${source_default.cyan("KUMA_JSON=1 kuma monitors list")}
+
+${source_default.dim("Exit codes:")}
+  ${source_default.yellow("0")}  Success
+  ${source_default.yellow("1")}  General error
+  ${source_default.yellow("2")}  Connection error
+  ${source_default.yellow("3")}  Not found
+  ${source_default.yellow("4")}  Auth error
+
 ${source_default.dim("Config stored at:")} ${source_default.yellow(getConfigPath())}
 `
 );
-program2.command("status").description("Show current connection config").action(() => {
+program2.command("status").description("Show current connection config").option("--json", "Output as JSON ({ ok, data })").action((opts) => {
+  const json = isJsonMode(opts);
   const config = getConfig();
   if (!config) {
+    if (json) {
+      jsonOut({ loggedIn: false });
+    }
     console.log(source_default.yellow("Not logged in. Run: kuma login <url>"));
-  } else {
-    console.log(source_default.green("\u2705 Logged in"));
-    console.log(`   URL:   ${source_default.cyan(config.url)}`);
-    console.log(
-      `   Token: ${source_default.dim(config.token.slice(0, 8) + "..." + config.token.slice(-4))}`
-    );
-    console.log(`   Config: ${source_default.dim(getConfigPath())}`);
+    return;
   }
+  if (json) {
+    jsonOut({
+      loggedIn: true,
+      url: config.url,
+      configPath: getConfigPath()
+    });
+  }
+  console.log(source_default.green("\u2705 Logged in"));
+  console.log(`   URL:   ${source_default.cyan(config.url)}`);
+  console.log(
+    `   Token: ${source_default.dim(config.token.slice(0, 8) + "..." + config.token.slice(-4))}`
+  );
+  console.log(`   Config: ${source_default.dim(getConfigPath())}`);
 });
 loginCommand(program2);
 logoutCommand(program2);

--- a/src/commands/heartbeat.ts
+++ b/src/commands/heartbeat.ts
@@ -6,6 +6,8 @@ import {
   statusLabel,
   formatPing,
   formatDate,
+  isJsonMode,
+  jsonOut,
 } from "../utils/output.js";
 import { handleError, requireAuth } from "../utils/errors.js";
 
@@ -14,10 +16,12 @@ export function heartbeatCommand(program: Command): void {
     .command("heartbeat <monitor-id>")
     .description("View recent heartbeats for a monitor")
     .option("--limit <n>", "Number of heartbeats to show", "20")
-    .option("--json", "Output raw JSON")
+    .option("--json", "Output as JSON ({ ok, data })")
     .action(async (monitorId: string, opts: { limit?: string; json?: boolean }) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+
+      const json = isJsonMode(opts);
 
       try {
         const client = await createAuthenticatedClient(
@@ -32,9 +36,8 @@ export function heartbeatCommand(program: Command): void {
         const limit = parseInt(opts.limit ?? "20", 10);
         const recent = heartbeats.slice(-limit).reverse();
 
-        if (opts.json) {
-          console.log(JSON.stringify(recent, null, 2));
-          return;
+        if (json) {
+          jsonOut(recent);
         }
 
         if (recent.length === 0) {
@@ -56,7 +59,7 @@ export function heartbeatCommand(program: Command): void {
         console.log(table.toString());
         console.log(`\nShowing last ${recent.length} heartbeat(s)`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import enquirer from "enquirer";
 import { KumaClient } from "../client.js";
 import { saveConfig } from "../config.js";
-import { success, error } from "../utils/output.js";
+import { success, error, isJsonMode, jsonOut } from "../utils/output.js";
 import { handleError } from "../utils/errors.js";
 
 const { prompt } = enquirer as any;
@@ -11,7 +11,10 @@ export function loginCommand(program: Command): void {
   program
     .command("login <url>")
     .description("Authenticate with Uptime Kuma and save session")
-    .action(async (url: string) => {
+    .option("--json", "Output as JSON ({ ok, data })")
+    .action(async (url: string, opts: { json?: boolean }) => {
+      const json = isJsonMode(opts);
+
       try {
         // Normalize URL
         const normalizedUrl = url.replace(/\/$/, "");
@@ -41,14 +44,23 @@ export function loginCommand(program: Command): void {
         client.disconnect();
 
         if (!result.ok || !result.token) {
-          error(result.msg ?? "Login failed");
+          const msg = result.msg ?? "Login failed";
+          if (json) {
+            jsonOut({ error: msg });
+          }
+          error(msg);
           process.exit(1);
         }
 
         saveConfig({ url: normalizedUrl, token: result.token });
+
+        if (json) {
+          jsonOut({ url: normalizedUrl, username });
+        }
+
         success(`Logged in as ${username} → ${normalizedUrl}`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,18 +1,30 @@
 import { Command } from "commander";
 import { clearConfig, getConfig } from "../config.js";
-import { success, warn } from "../utils/output.js";
+import { success, warn, isJsonMode, jsonOut } from "../utils/output.js";
 
 export function logoutCommand(program: Command): void {
   program
     .command("logout")
     .description("Clear saved session credentials")
-    .action(() => {
+    .option("--json", "Output as JSON ({ ok, data })")
+    .action((opts: { json?: boolean }) => {
+      const json = isJsonMode(opts);
       const config = getConfig();
+
       if (!config) {
+        if (json) {
+          jsonOut({ loggedOut: false, reason: "Not currently logged in" });
+        }
         warn("Not currently logged in.");
         return;
       }
+
       clearConfig();
+
+      if (json) {
+        jsonOut({ loggedOut: true });
+      }
+
       success("Logged out. Run `kuma login <url>` to authenticate again.");
     });
 }

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -9,6 +9,8 @@ import {
   formatPing,
   success,
   error,
+  isJsonMode,
+  jsonOut,
 } from "../utils/output.js";
 import { handleError, requireAuth } from "../utils/errors.js";
 
@@ -37,7 +39,7 @@ export function monitorsCommand(program: Command): void {
   monitors
     .command("list")
     .description("List all monitors")
-    .option("--json", "Output raw JSON")
+    .option("--json", "Output as JSON ({ ok, data })")
     .option(
       "--status <status>",
       "Filter by status: up, down, pending, maintenance"
@@ -46,7 +48,9 @@ export function monitorsCommand(program: Command): void {
     .action(
       async (opts: { json?: boolean; status?: string; tag?: string }) => {
         const config = getConfig();
-        if (!config) requireAuth();
+        if (!config) requireAuth(opts);
+
+        const json = isJsonMode(opts);
 
         // Map human-readable status strings to numeric values
         const STATUS_MAP: Record<string, number> = {
@@ -70,6 +74,9 @@ export function monitorsCommand(program: Command): void {
           if (opts.status) {
             const statusKey = opts.status.toLowerCase();
             if (!(statusKey in STATUS_MAP)) {
+              if (json) {
+                jsonOut({ error: `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance` });
+              }
               error(
                 `Invalid status "${opts.status}". Valid values: up, down, pending, maintenance`
               );
@@ -78,7 +85,6 @@ export function monitorsCommand(program: Command): void {
             const statusNum = STATUS_MAP[statusKey];
             list = list.filter((m: Monitor) => {
               if (m.heartbeat) return m.heartbeat.status === statusNum;
-              // For monitors with no heartbeat yet, match "pending" (2)
               if (statusNum === 2) return m.active && !m.heartbeat;
               return false;
             });
@@ -94,9 +100,8 @@ export function monitorsCommand(program: Command): void {
             );
           }
 
-          if (opts.json) {
-            console.log(JSON.stringify(list, null, 2));
-            return;
+          if (json) {
+            jsonOut(list);
           }
 
           if (list.length === 0) {
@@ -136,7 +141,7 @@ export function monitorsCommand(program: Command): void {
           console.log(table.toString());
           console.log(`\n${list.length} monitor(s) total`);
         } catch (err) {
-          handleError(err);
+          handleError(err, opts);
         }
       }
     );
@@ -149,15 +154,19 @@ export function monitorsCommand(program: Command): void {
     .option("--type <type>", "Monitor type (http, tcp, ping, ...)")
     .option("--url <url>", "URL or hostname to monitor")
     .option("--interval <seconds>", "Check interval in seconds", "60")
+    .option("--json", "Output as JSON ({ ok, data })")
     .action(
       async (opts: {
         name?: string;
         type?: string;
         url?: string;
         interval?: string;
+        json?: boolean;
       }) => {
         const config = getConfig();
-        if (!config) requireAuth();
+        if (!config) requireAuth(opts);
+
+        const json = isJsonMode(opts);
 
         try {
           const answers = await prompt([
@@ -197,9 +206,13 @@ export function monitorsCommand(program: Command): void {
           const result = await client.addMonitor({ name, type, url, interval });
           client.disconnect();
 
+          if (json) {
+            jsonOut({ id: result.id, name, type, url, interval });
+          }
+
           success(`Monitor "${name}" created (ID: ${result.id})`);
         } catch (err) {
-          handleError(err);
+          handleError(err, opts);
         }
       }
     );
@@ -213,6 +226,7 @@ export function monitorsCommand(program: Command): void {
     .option("--interval <seconds>", "New check interval in seconds")
     .option("--active", "Activate (resume) the monitor")
     .option("--no-active", "Deactivate (pause) the monitor")
+    .option("--json", "Output as JSON ({ ok, data })")
     .action(
       async (
         id: string,
@@ -221,18 +235,18 @@ export function monitorsCommand(program: Command): void {
           url?: string;
           interval?: string;
           active?: boolean;
+          json?: boolean;
         }
       ) => {
         const config = getConfig();
-        if (!config) requireAuth();
+        if (!config) requireAuth(opts);
 
+        const json = isJsonMode(opts);
         const monitorId = parseInt(id, 10);
         if (isNaN(monitorId)) {
-          error(`Invalid monitor ID: ${id}`);
-          process.exit(1);
+          handleError(new Error(`Invalid monitor ID: ${id}`), opts);
         }
 
-        // Determine which fields were explicitly provided
         const hasPatch =
           opts.name !== undefined ||
           opts.url !== undefined ||
@@ -240,10 +254,10 @@ export function monitorsCommand(program: Command): void {
           opts.active !== undefined;
 
         if (!hasPatch) {
-          error(
-            "No fields to update. Use --name, --url, --interval, --active, or --no-active."
+          handleError(
+            new Error("No fields to update. Use --name, --url, --interval, --active, or --no-active."),
+            opts
           );
-          process.exit(1);
         }
 
         try {
@@ -252,24 +266,20 @@ export function monitorsCommand(program: Command): void {
             config!.token
           );
 
-          // Fetch full monitor list so we can send the complete object back
-          // (Kuma's editMonitor requires all fields, not just the diff)
           const monitorMap = await client.getMonitorList();
           const existing = monitorMap[String(monitorId)];
 
           if (!existing) {
             client.disconnect();
             const ids = Object.keys(monitorMap).join(", ");
-            error(
-              `Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`
+            handleError(
+              new Error(`Monitor ${monitorId} not found. Available IDs: ${ids || "none"}`),
+              opts
             );
-            process.exit(1);
           }
 
-          // Build a human-readable summary of what changed
           const changes: string[] = [];
 
-          // Apply field changes via editMonitor (name, url, interval)
           const hasFieldChanges =
             opts.name !== undefined ||
             opts.url !== undefined ||
@@ -292,8 +302,6 @@ export function monitorsCommand(program: Command): void {
             await client.editMonitor(monitorId, updated);
           }
 
-          // Apply active/inactive via pauseMonitor / resumeMonitor
-          // (editMonitor ignores the active field — Kuma uses separate events)
           if (opts.active !== undefined) {
             if (opts.active) {
               await client.resumeMonitor(monitorId);
@@ -305,9 +313,14 @@ export function monitorsCommand(program: Command): void {
           }
 
           client.disconnect();
+
+          if (json) {
+            jsonOut({ id: monitorId, changes });
+          }
+
           success(`Monitor ${monitorId} updated (${changes.join(", ")})`);
         } catch (err) {
-          handleError(err);
+          handleError(err, opts);
         }
       }
     );
@@ -317,12 +330,16 @@ export function monitorsCommand(program: Command): void {
     .command("delete <id>")
     .description("Delete a monitor")
     .option("--force", "Skip confirmation")
-    .action(async (id: string, opts: { force?: boolean }) => {
+    .option("--json", "Output as JSON ({ ok, data })")
+    .action(async (id: string, opts: { force?: boolean; json?: boolean }) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+
+      const json = isJsonMode(opts);
 
       try {
-        if (!opts.force) {
+        if (!opts.force && !json) {
+          // Skip prompt in JSON mode — caller drives non-interactive flows
           const { confirm } = (await prompt({
             type: "confirm",
             name: "confirm",
@@ -342,9 +359,13 @@ export function monitorsCommand(program: Command): void {
         await client.deleteMonitor(parseInt(id, 10));
         client.disconnect();
 
+        if (json) {
+          jsonOut({ id: parseInt(id, 10), deleted: true });
+        }
+
         success(`Monitor ${id} deleted`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 
@@ -352,9 +373,12 @@ export function monitorsCommand(program: Command): void {
   monitors
     .command("pause <id>")
     .description("Pause a monitor")
-    .action(async (id: string) => {
+    .option("--json", "Output as JSON ({ ok, data })")
+    .action(async (id: string, opts: { json?: boolean }) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+
+      const json = isJsonMode(opts);
 
       try {
         const client = await createAuthenticatedClient(
@@ -363,9 +387,14 @@ export function monitorsCommand(program: Command): void {
         );
         await client.pauseMonitor(parseInt(id, 10));
         client.disconnect();
+
+        if (json) {
+          jsonOut({ id: parseInt(id, 10), paused: true });
+        }
+
         success(`Monitor ${id} paused`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 
@@ -373,9 +402,12 @@ export function monitorsCommand(program: Command): void {
   monitors
     .command("resume <id>")
     .description("Resume a monitor")
-    .action(async (id: string) => {
+    .option("--json", "Output as JSON ({ ok, data })")
+    .action(async (id: string, opts: { json?: boolean }) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+
+      const json = isJsonMode(opts);
 
       try {
         const client = await createAuthenticatedClient(
@@ -384,9 +416,14 @@ export function monitorsCommand(program: Command): void {
         );
         await client.resumeMonitor(parseInt(id, 10));
         client.disconnect();
+
+        if (json) {
+          jsonOut({ id: parseInt(id, 10), resumed: true });
+        }
+
         success(`Monitor ${id} resumed`);
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 }

--- a/src/commands/status-pages.ts
+++ b/src/commands/status-pages.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import chalk from "chalk";
 import { createAuthenticatedClient } from "../client.js";
 import { getConfig } from "../config.js";
-import { createTable } from "../utils/output.js";
+import { createTable, isJsonMode, jsonOut } from "../utils/output.js";
 import { handleError, requireAuth } from "../utils/errors.js";
 
 export function statusPagesCommand(program: Command): void {
@@ -12,10 +12,12 @@ export function statusPagesCommand(program: Command): void {
 
   sp.command("list")
     .description("List all status pages")
-    .option("--json", "Output raw JSON")
+    .option("--json", "Output as JSON ({ ok, data })")
     .action(async (opts: { json?: boolean }) => {
       const config = getConfig();
-      if (!config) requireAuth();
+      if (!config) requireAuth(opts);
+
+      const json = isJsonMode(opts);
 
       try {
         const client = await createAuthenticatedClient(
@@ -27,9 +29,8 @@ export function statusPagesCommand(program: Command): void {
 
         const list = Object.values(pages);
 
-        if (opts.json) {
-          console.log(JSON.stringify(list, null, 2));
-          return;
+        if (json) {
+          jsonOut(list);
         }
 
         if (list.length === 0) {
@@ -52,7 +53,7 @@ export function statusPagesCommand(program: Command): void {
 
         console.log(table.toString());
       } catch (err) {
-        handleError(err);
+        handleError(err, opts);
       }
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { heartbeatCommand } from "./commands/heartbeat.js";
 import { statusPagesCommand } from "./commands/status-pages.js";
 import { getConfig, getConfigPath } from "./config.js";
 import chalk from "chalk";
+import { isJsonMode, jsonOut } from "./utils/output.js";
 
 const program = new Command();
 
@@ -23,6 +24,17 @@ ${chalk.dim("Examples:")}
   ${chalk.cyan("kuma heartbeat 1")}
   ${chalk.cyan("kuma logout")}
 
+${chalk.dim("JSON mode (any command):")}
+  ${chalk.cyan("kuma monitors list --json")}
+  ${chalk.cyan("KUMA_JSON=1 kuma monitors list")}
+
+${chalk.dim("Exit codes:")}
+  ${chalk.yellow("0")}  Success
+  ${chalk.yellow("1")}  General error
+  ${chalk.yellow("2")}  Connection error
+  ${chalk.yellow("3")}  Not found
+  ${chalk.yellow("4")}  Auth error
+
 ${chalk.dim("Config stored at:")} ${chalk.yellow(getConfigPath())}
 `
   );
@@ -31,18 +43,33 @@ ${chalk.dim("Config stored at:")} ${chalk.yellow(getConfigPath())}
 program
   .command("status")
   .description("Show current connection config")
-  .action(() => {
+  .option("--json", "Output as JSON ({ ok, data })")
+  .action((opts: { json?: boolean }) => {
+    const json = isJsonMode(opts);
     const config = getConfig();
+
     if (!config) {
+      if (json) {
+        jsonOut({ loggedIn: false });
+      }
       console.log(chalk.yellow("Not logged in. Run: kuma login <url>"));
-    } else {
-      console.log(chalk.green("✅ Logged in"));
-      console.log(`   URL:   ${chalk.cyan(config.url)}`);
-      console.log(
-        `   Token: ${chalk.dim(config.token.slice(0, 8) + "..." + config.token.slice(-4))}`
-      );
-      console.log(`   Config: ${chalk.dim(getConfigPath())}`);
+      return;
     }
+
+    if (json) {
+      jsonOut({
+        loggedIn: true,
+        url: config.url,
+        configPath: getConfigPath(),
+      });
+    }
+
+    console.log(chalk.green("✅ Logged in"));
+    console.log(`   URL:   ${chalk.cyan(config.url)}`);
+    console.log(
+      `   Token: ${chalk.dim(config.token.slice(0, 8) + "..." + config.token.slice(-4))}`
+    );
+    console.log(`   Config: ${chalk.dim(getConfigPath())}`);
   });
 
 // Register all commands

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,15 +1,61 @@
-import { error } from "./output.js";
+import { error, isJsonMode, jsonError } from "./output.js";
 
-export function handleError(err: unknown, exitCode = 1): never {
-  if (err instanceof Error) {
-    error(err.message);
-  } else {
-    error(String(err));
+/**
+ * Exit codes:
+ *   0  Success
+ *   1  General error
+ *   2  Connection error
+ *   3  Not found
+ *   4  Auth error
+ */
+export const EXIT_CODES = {
+  SUCCESS: 0,
+  GENERAL: 1,
+  CONNECTION: 2,
+  NOT_FOUND: 3,
+  AUTH: 4,
+} as const;
+
+/**
+ * Determine a meaningful exit code from an error object.
+ * Looks at the message for known patterns; defaults to GENERAL (1).
+ */
+function exitCodeFor(err: unknown): number {
+  if (!(err instanceof Error)) return EXIT_CODES.GENERAL;
+  const msg = err.message.toLowerCase();
+  if (msg.includes("connection") || msg.includes("timeout") || msg.includes("refused")) {
+    return EXIT_CODES.CONNECTION;
   }
-  process.exit(exitCode);
+  if (msg.includes("not found") || msg.includes("not exist")) {
+    return EXIT_CODES.NOT_FOUND;
+  }
+  if (msg.includes("auth") || msg.includes("session expired") || msg.includes("login")) {
+    return EXIT_CODES.AUTH;
+  }
+  return EXIT_CODES.GENERAL;
 }
 
-export function requireAuth(): never {
-  error("Not authenticated. Run: kuma login <url>");
-  process.exit(1);
+/**
+ * Central error handler. When JSON mode is active, outputs structured JSON to
+ * stdout (so pipes work). Otherwise prints a human-readable message to stderr.
+ */
+export function handleError(err: unknown, opts?: { json?: boolean }): never {
+  const message = err instanceof Error ? err.message : String(err);
+  const code = exitCodeFor(err);
+
+  if (isJsonMode(opts)) {
+    jsonError(message, code);
+  }
+
+  error(message);
+  process.exit(code);
+}
+
+export function requireAuth(opts?: { json?: boolean }): never {
+  const message = "Not authenticated. Run: kuma login <url>";
+  if (isJsonMode(opts)) {
+    jsonError(message, EXIT_CODES.AUTH);
+  }
+  error(message);
+  process.exit(EXIT_CODES.AUTH);
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -71,3 +71,37 @@ export function formatPing(ping?: number): string {
 export function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleString();
 }
+
+// ---------------------------------------------------------------------------
+// JSON mode helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when JSON output is requested — either via the `--json` flag
+ * passed to a command, or the `KUMA_JSON` environment variable being set to
+ * any truthy value ("1", "true", "yes").
+ */
+export function isJsonMode(opts?: { json?: boolean }): boolean {
+  if (opts?.json) return true;
+  const env = process.env["KUMA_JSON"];
+  return env === "1" || env === "true" || env === "yes";
+}
+
+/**
+ * Emit a successful JSON response to stdout and exit 0.
+ * Shape: `{ "ok": true, "data": <payload> }`
+ */
+export function jsonOut(data: unknown): never {
+  console.log(JSON.stringify({ ok: true, data }, null, 2));
+  process.exit(0);
+}
+
+/**
+ * Emit an error JSON response to stdout (not stderr — so pipes work) and exit
+ * with the given code.
+ * Shape: `{ "ok": false, "error": "<message>", "code": <exitCode> }`
+ */
+export function jsonError(message: string, code = 1): never {
+  console.log(JSON.stringify({ ok: false, error: message, code }, null, 2));
+  process.exit(code);
+}


### PR DESCRIPTION
Closes #17

## Summary

Adds full JSON mode support to **all** kuma-cli commands, making the CLI first-class for scripting, CI pipelines, and agent workflows.

## Changes

### Core helpers (utils/output.ts)
- `isJsonMode(opts?)` — checks `--json` flag **or** `KUMA_JSON` env var (`1`, `true`, `yes`)
- `jsonOut(data)` — emits `{ ok: true, data }` to stdout, exits 0
- `jsonError(msg, code)` — emits `{ ok: false, error, code }` to stdout, exits with code

### Error handling (utils/errors.ts)
- `handleError()` / `requireAuth()` are now JSON-aware — route to `jsonError()` in JSON mode
- Added `EXIT_CODES` const (0=success, 1=general, 2=connection, 3=not-found, 4=auth)
- Auto-infers semantic exit code from error message

### Commands updated
All commands now accept `--json` and respect `KUMA_JSON`:
- `monitors list / add / update / delete / pause / resume`
- `heartbeat`
- `status-pages list`
- `login / logout`
- `status`

## Output shapes

```json
// Success
{ "ok": true, "data": { ... } }

// Error
{ "ok": false, "error": "Connection refused", "code": 2 }
```

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Success |
| 1 | General error |
| 2 | Connection error |
| 3 | Not found |
| 4 | Auth error |

## Usage

```bash
# Per-command flag
kuma monitors list --json
kuma monitors pause 42 --json

# Global env var — activates for ALL commands
KUMA_JSON=1 kuma monitors list
KUMA_JSON=1 kuma heartbeat 1

# Pipe-safe errors (go to stdout, not stderr)
kuma monitors list --json | jq '.data[] | .name'
```

## Notes
- Human-readable output is **unchanged** when `--json` is not used — no regressions
- In JSON mode, `monitors delete` skips the interactive confirmation prompt (non-interactive by design)
- Errors go to **stdout** in JSON mode so piping works correctly