### PR TITLE
feat: kuma upgrade — self-update command

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30416,6 +30416,133 @@ function statusPagesCommand(program3) {
   });
 }
 
+// src/commands/upgrade.ts
+var import_child_process = require("child_process");
+var import_fs = require("fs");
+var import_path = require("path");
+function readCurrentVersion() {
+  try {
+    const pkgPath = (0, import_path.join)(__dirname, "..", "package.json");
+    const raw = (0, import_fs.readFileSync)(pkgPath, "utf8");
+    const pkg = JSON.parse(raw);
+    if (pkg.version) return pkg.version;
+  } catch {
+  }
+  try {
+    const pkgPath = (0, import_path.join)(__dirname, "package.json");
+    const raw = (0, import_fs.readFileSync)(pkgPath, "utf8");
+    const pkg = JSON.parse(raw);
+    if (pkg.version) return pkg.version;
+  } catch {
+  }
+  return "unknown";
+}
+async function fetchLatestRelease() {
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/BlackAsteroid/kuma-cli/releases/latest",
+      {
+        headers: {
+          "User-Agent": "kuma-cli-upgrade",
+          Accept: "application/vnd.github+json"
+        },
+        signal: AbortSignal.timeout(1e4)
+      }
+    );
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+function compareSemver(a, b) {
+  const pa = a.replace(/^v/, "").split(".").map(Number);
+  const pb = b.replace(/^v/, "").split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff < 0) return -1;
+    if (diff > 0) return 1;
+  }
+  return 0;
+}
+function upgradeCommand(program3) {
+  program3.command("upgrade").description(
+    "Update kuma-cli to the latest version from GitHub"
+  ).option("--json", "Output as JSON ({ ok, data })").addHelpText(
+    "after",
+    `
+${source_default.dim("Examples:")}
+  ${source_default.cyan("kuma upgrade")}              Check for updates and upgrade if available
+  ${source_default.cyan("kuma upgrade --json")}       Machine-readable upgrade result
+`
+  ).action(async (opts) => {
+    const json = isJsonMode(opts);
+    const current = readCurrentVersion();
+    if (!json) {
+      console.log(`Current version: ${source_default.cyan(`v${current}`)}`);
+      process.stdout.write("Checking for latest release\u2026 ");
+    }
+    const release = await fetchLatestRelease();
+    if (!release) {
+      if (!json) console.log(source_default.red("failed"));
+      const msg = "Could not reach GitHub. Check your internet connection and try again.";
+      if (json) jsonError(msg, 2);
+      console.error(source_default.red(`
+\u274C ${msg}`));
+      process.exit(2);
+    }
+    const latest = release.tag_name.replace(/^v/, "");
+    if (!json) console.log(source_default.green("done"));
+    if (compareSemver(current, latest) >= 0) {
+      if (json) {
+        jsonOut({ current, latest, upgraded: false, reason: "Already up to date" });
+      }
+      console.log(
+        `Latest version: ${source_default.cyan(`v${latest}`)}
+` + source_default.green("\u2705 Already up to date \u2014 nothing to do.")
+      );
+      return;
+    }
+    if (!json) {
+      console.log(`Latest version:  ${source_default.cyan(`v${latest}`)}`);
+      console.log(
+        `
+${source_default.bold(`Upgrading kuma-cli`)} ${source_default.dim(`v${current}`)} \u2192 ${source_default.green(`v${latest}`)}\u2026`
+      );
+    }
+    try {
+      (0, import_child_process.execSync)("npm install -g github:BlackAsteroid/kuma-cli", {
+        stdio: json ? "pipe" : "inherit"
+      });
+    } catch (err) {
+      const raw = err instanceof Error ? err.message : String(err);
+      const isPermission = raw.toLowerCase().includes("permission") || raw.toLowerCase().includes("eacces") || raw.toLowerCase().includes("eperm");
+      if (json) {
+        jsonError(
+          isPermission ? "Permission denied. Try running with elevated permissions (sudo)." : `Upgrade failed: ${raw}`,
+          isPermission ? 4 : 1
+        );
+      }
+      if (isPermission) {
+        console.error(
+          source_default.red("\n\u274C Permission denied.") + " Try running with elevated permissions:\n" + source_default.cyan("   sudo kuma upgrade")
+        );
+      } else {
+        console.error(source_default.red(`
+\u274C Upgrade failed: ${raw}`));
+      }
+      process.exit(isPermission ? 4 : 1);
+    }
+    if (json) {
+      jsonOut({ current, latest, upgraded: true });
+    }
+    console.log(
+      source_default.green(`
+\u2705 kuma-cli upgraded to v${latest} successfully!`)
+    );
+  });
+}
+
 // src/index.ts
 var program2 = new Command();
 program2.name("kuma").description("CLI for managing Uptime Kuma via Socket.IO API").version("0.1.0").addHelpText(
@@ -30471,6 +30598,7 @@ logoutCommand(program2);
 monitorsCommand(program2);
 heartbeatCommand(program2);
 statusPagesCommand(program2);
+upgradeCommand(program2);
 program2.parse(process.argv);
 /*! Bundled license information:
 

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,0 +1,183 @@
+import { Command } from "commander";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { isJsonMode, jsonOut, jsonError } from "../utils/output.js";
+import chalk from "chalk";
+
+/**
+ * Read the version from package.json at build time.
+ * Works in both ESM (via import) and CJS bundles (via fs.readFileSync).
+ * We walk up from __dirname until we find a package.json with a "version".
+ */
+function readCurrentVersion(): string {
+  // tsup bundles to dist/index.js; package.json is one level up
+  try {
+    const pkgPath = join(__dirname, "..", "package.json");
+    const raw = readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as { version?: string };
+    if (pkg.version) return pkg.version;
+  } catch {
+    // fallback: try same dir
+  }
+  try {
+    const pkgPath = join(__dirname, "package.json");
+    const raw = readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as { version?: string };
+    if (pkg.version) return pkg.version;
+  } catch {
+    // ignore
+  }
+  return "unknown";
+}
+
+
+interface GithubRelease {
+  tag_name: string;
+  name: string;
+  html_url: string;
+}
+
+/**
+ * Fetch the latest published release from GitHub.
+ * Returns null on network error (so the caller can handle gracefully).
+ */
+async function fetchLatestRelease(): Promise<GithubRelease | null> {
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/BlackAsteroid/kuma-cli/releases/latest",
+      {
+        headers: {
+          "User-Agent": "kuma-cli-upgrade",
+          Accept: "application/vnd.github+json",
+        },
+        signal: AbortSignal.timeout(10_000),
+      }
+    );
+    if (!res.ok) return null;
+    return (await res.json()) as GithubRelease;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two semver strings (without leading 'v').
+ * Returns: -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareSemver(a: string, b: string): -1 | 0 | 1 {
+  const pa = a.replace(/^v/, "").split(".").map(Number);
+  const pb = b.replace(/^v/, "").split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff < 0) return -1;
+    if (diff > 0) return 1;
+  }
+  return 0;
+}
+
+export function upgradeCommand(program: Command): void {
+  program
+    .command("upgrade")
+    .description(
+      "Update kuma-cli to the latest version from GitHub"
+    )
+    .option("--json", "Output as JSON ({ ok, data })")
+    .addHelpText(
+      "after",
+      `
+${chalk.dim("Examples:")}
+  ${chalk.cyan("kuma upgrade")}              Check for updates and upgrade if available
+  ${chalk.cyan("kuma upgrade --json")}       Machine-readable upgrade result
+`
+    )
+    .action(async (opts: { json?: boolean }) => {
+      const json = isJsonMode(opts);
+
+      // --- Current version ---
+      const current = readCurrentVersion();
+
+      if (!json) {
+        console.log(`Current version: ${chalk.cyan(`v${current}`)}`);
+        process.stdout.write("Checking for latest release… ");
+      }
+
+      // --- Latest version ---
+      const release = await fetchLatestRelease();
+
+      if (!release) {
+        if (!json) console.log(chalk.red("failed"));
+        const msg =
+          "Could not reach GitHub. Check your internet connection and try again.";
+        if (json) jsonError(msg, 2);
+        console.error(chalk.red(`\n❌ ${msg}`));
+        process.exit(2);
+      }
+
+      const latest = release.tag_name.replace(/^v/, "");
+
+      if (!json) console.log(chalk.green("done"));
+
+      if (compareSemver(current, latest) >= 0) {
+        // Already up to date
+        if (json) {
+          jsonOut({ current, latest, upgraded: false, reason: "Already up to date" });
+        }
+        console.log(
+          `Latest version: ${chalk.cyan(`v${latest}`)}\n` +
+            chalk.green("✅ Already up to date — nothing to do.")
+        );
+        return;
+      }
+
+      // --- Upgrade ---
+      if (!json) {
+        console.log(`Latest version:  ${chalk.cyan(`v${latest}`)}`);
+        console.log(
+          `\n${chalk.bold(`Upgrading kuma-cli`)} ${chalk.dim(`v${current}`)} → ${chalk.green(`v${latest}`)}…`
+        );
+      }
+
+      try {
+        execSync("npm install -g github:BlackAsteroid/kuma-cli", {
+          stdio: json ? "pipe" : "inherit",
+        });
+      } catch (err: unknown) {
+        const raw = err instanceof Error ? err.message : String(err);
+
+        // Surface permission errors with a helpful hint
+        const isPermission =
+          raw.toLowerCase().includes("permission") ||
+          raw.toLowerCase().includes("eacces") ||
+          raw.toLowerCase().includes("eperm");
+
+        if (json) {
+          jsonError(
+            isPermission
+              ? "Permission denied. Try running with elevated permissions (sudo)."
+              : `Upgrade failed: ${raw}`,
+            isPermission ? 4 : 1
+          );
+        }
+
+        if (isPermission) {
+          console.error(
+            chalk.red("\n❌ Permission denied.") +
+              " Try running with elevated permissions:\n" +
+              chalk.cyan("   sudo kuma upgrade")
+          );
+        } else {
+          console.error(chalk.red(`\n❌ Upgrade failed: ${raw}`));
+        }
+        process.exit(isPermission ? 4 : 1);
+      }
+
+      if (json) {
+        jsonOut({ current, latest, upgraded: true });
+      }
+
+      console.log(
+        chalk.green(`\n✅ kuma-cli upgraded to v${latest} successfully!`)
+      );
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { logoutCommand } from "./commands/logout.js";
 import { monitorsCommand } from "./commands/monitors.js";
 import { heartbeatCommand } from "./commands/heartbeat.js";
 import { statusPagesCommand } from "./commands/status-pages.js";
+import { upgradeCommand } from "./commands/upgrade.js";
 import { getConfig, getConfigPath } from "./config.js";
 import chalk from "chalk";
 import { isJsonMode, jsonOut } from "./utils/output.js";
@@ -78,5 +79,6 @@ logoutCommand(program);
 monitorsCommand(program);
 heartbeatCommand(program);
 statusPagesCommand(program);
+upgradeCommand(program);
 
 program.parse(process.argv);


### PR DESCRIPTION
Closes #15

## Summary

Adds `kuma upgrade` — a self-update command that upgrades kuma-cli to the latest version directly from the terminal.

## Usage

```bash
kuma upgrade           # Check for update and upgrade if needed
kuma upgrade --json    # Machine-readable output
```

## Output flow

```
Current version: v0.1.0
Checking for latest release… done
Latest version:  v0.2.0

Upgrading kuma-cli v0.1.0 → v0.2.0…
[npm install output]

✅ kuma-cli upgraded to v0.2.0 successfully!
```

## Already up to date

```
Current version: v0.2.0
Checking for latest release… done
Latest version:  v0.2.0
✅ Already up to date — nothing to do.
```

## JSON mode

```json
// Upgraded
{ "ok": true, "data": { "current": "0.1.0", "latest": "0.2.0", "upgraded": true } }

// Already up to date
{ "ok": true, "data": { "current": "0.2.0", "latest": "0.2.0", "upgraded": false, "reason": "Already up to date" } }

// Network error
{ "ok": false, "error": "Could not reach GitHub...", "code": 2 }

// Permission denied
{ "ok": false, "error": "Permission denied. Try running with elevated permissions (sudo).", "code": 4 }
```

## Implementation details

- Version read from `package.json` via `fs.readFileSync` (compatible with CJS bundle — no `import.meta`)
- Latest version fetched via GitHub Releases API (`/repos/BlackAsteroid/kuma-cli/releases/latest`)
- Upgrade runs: `npm install -g github:BlackAsteroid/kuma-cli`
- Semver comparison handles `v` prefix and all three components
- Full `--json` / `KUMA_JSON=1` support consistent with all other commands

## Exit codes

| Code | Meaning |
|------|---------|
| 0 | Success / already up to date |
| 1 | General upgrade failure |
| 2 | Network/connection error |
| 4 | Permission denied |