### PR TITLE
chore: add publishConfig for npm public registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "dist/",
     "README.md"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary

Adds `publishConfig.access: "public"` to `package.json` so `@blackasteroid/kuma-cli` can be published to the public npm registry.

## Why

Scoped packages (`@org/pkg`) default to **private** on npm, which requires a paid plan. Without this flag, `npm publish` fails with:

```
npm error 402 Payment Required
```

With `publishConfig.access: "public"` set, the package publishes to the free public registry.

## What's already correct (no changes needed)

- ✅ `name`: `@blackasteroid/kuma-cli`
- ✅ `version`: `0.1.0`
- ✅ `files`: `["dist/", "README.md"]` — only ships what's needed
- ✅ `prepublishOnly`: `npm run build` — auto-builds before publish
- ✅ `bin.kuma`: `./dist/index.js` — CLI entry point
- ✅ `dist/index.js` has `#!/usr/bin/env node` shebang

## Dry run

```
📦  @blackasteroid/kuma-cli@0.1.0
  3.9kB  README.md
  1.1MB  dist/index.js
  986B   package.json
  total: 3 files, 214.6 kB compressed
```

## After merge

Once merged, whoever has npm publish rights for `@blackasteroid` runs:

```bash
npm publish
```

Users can then install with:

```bash
npm install -g @blackasteroid/kuma-cli
# or without installing:
npx @blackasteroid/kuma-cli --help
```