### PR TITLE
feat: monitors create, bulk-pause/resume, heartbeat send (#24, #26, #28)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27808,6 +27808,7 @@ var KumaClient = class {
   // BUG-01 fix: addMonitor uses callback, not a separate event
   // BUG-03 fix: include required fields accepted_statuscodes, maxretries, retryInterval
   async addMonitor(monitor) {
+    const autoToken = monitor.type === "push" && !monitor.pushToken ? Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("") : void 0;
     const payload = {
       accepted_statuscodes: ["200-299"],
       maxretries: 1,
@@ -27816,6 +27817,7 @@ var KumaClient = class {
       rabbitmqNodes: [],
       kafkaProducerBrokers: [],
       kafkaProducerSaslOptions: { mechanism: "none" },
+      ...autoToken ? { pushToken: autoToken } : {},
       ...monitor
     };
     return new Promise((resolve, reject) => {
@@ -27832,7 +27834,11 @@ var KumaClient = class {
             reject(new Error(result.msg ?? "Failed to add monitor"));
             return;
           }
-          resolve({ id: result.monitorID });
+          resolve({
+            id: result.monitorID,
+            // Return the token we generated so the caller has it immediately
+            pushToken: payload.pushToken
+          });
         }
       );
     });
@@ -30291,9 +30297,9 @@ function isJsonMode(opts) {
   const env3 = process.env["KUMA_JSON"];
   return env3 === "1" || env3 === "true" || env3 === "yes";
 }
-function jsonOut(data) {
+function jsonOut(data, exitCode = 0) {
   console.log(JSON.stringify({ ok: true, data }, null, 2));
-  process.exit(0);
+  process.exit(exitCode);
 }
 function jsonError(message, code = 1) {
   console.log(JSON.stringify({ ok: false, error: message, code }, null, 2));
@@ -30606,18 +30612,19 @@ ${source_default.dim("Examples:")}
       }
     }
   );
-  monitors.command("create").description("Create a monitor non-interactively \u2014 designed for CI/CD pipelines").requiredOption("--name <name>", "Monitor display name").requiredOption("--type <type>", "Monitor type: http, tcp, ping, dns, push, ...").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds (default: 60)", "60").option("--tag <tag>", "Assign a tag by name (repeatable)", collect, []).option("--notification-id <id>", "Assign a notification channel by ID (repeatable)", collectInt, []).option("--json", "Output as JSON ({ ok, data }) \u2014 prints monitor ID to stdout").addHelpText(
+  monitors.command("create").description("Create a monitor non-interactively \u2014 designed for CI/CD pipelines").requiredOption("--name <name>", "Monitor display name").requiredOption("--type <type>", "Monitor type: http, tcp, ping, dns, push, ...").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds (default: 60)", "60").option("--tag <tag>", "Assign a tag by name (repeatable \u2014 must already exist in Kuma)", collect, []).option("--notification-id <id>", "Assign a notification channel by ID (repeatable)", collectInt, []).option("--json", "Output as JSON ({ ok, data }) \u2014 prints monitor ID and pushToken to stdout").addHelpText(
     "after",
     `
 ${source_default.dim("Examples:")}
   ${source_default.cyan('kuma monitors create --type http --name "habitu.ar" --url https://habitu.ar')}
   ${source_default.cyan('kuma monitors create --type http --name "My API" --url https://api.example.com --tag Production --tag BlackAsteroid')}
-  ${source_default.cyan(`kuma monitors create --type push --name "GH Runner" --json | jq '.data.id'`)}
+  ${source_default.cyan(`kuma monitors create --type push --name "GH Runner" --json | jq '.data.pushToken'`)}
   ${source_default.cyan('kuma monitors create --type tcp --name "DB" --url db.host:5432 --interval 30 --notification-id 1')}
 
-${source_default.dim("Pipeline usage:")}
-  ${source_default.cyan(`MONITOR_ID=$(kuma monitors create --type http --name "svc" --url https://svc.example.com --json | jq '.data.id')`)}
-  ${source_default.cyan("kuma monitors set-notification $MONITOR_ID --notification-id $NOTIF_ID")}
+${source_default.dim("Full pipeline (deploy \u2192 monitor \u2192 heartbeat):")}
+  ${source_default.cyan('RESULT=$(kuma monitors create --type push --name "runner" --json)')}
+  ${source_default.cyan("PUSH_TOKEN=$(echo $RESULT | jq -r '.data.pushToken')")}
+  ${source_default.cyan('kuma heartbeat send $PUSH_TOKEN --msg "Alive"')}
 `
   ).action(async (opts) => {
     const config = getConfig();
@@ -30636,14 +30643,18 @@ ${source_default.dim("Pipeline usage:")}
         interval
       });
       const monitorId = result.id;
+      let pushToken = result.pushToken ?? null;
+      const tagWarnings = [];
       if (opts.tag.length > 0) {
         const allTags = await client.getTags();
         const tagMap = new Map(allTags.map((t) => [t.name.toLowerCase(), t]));
         for (const tagName of opts.tag) {
           const found = tagMap.get(tagName.toLowerCase());
           if (!found) {
+            const warn2 = `Tag "${tagName}" not found \u2014 skipping. Create it in the Kuma UI first.`;
+            tagWarnings.push(warn2);
             if (!json) {
-              error(`Tag "${tagName}" not found \u2014 skipping (create it in the Kuma UI first)`);
+              console.warn(source_default.yellow(`\u26A0\uFE0F  ${warn2}`));
             }
             continue;
           }
@@ -30658,11 +30669,28 @@ ${source_default.dim("Pipeline usage:")}
       }
       client.disconnect();
       if (json) {
-        jsonOut({ id: monitorId, name: opts.name, type: opts.type, url: opts.url, interval });
+        const data = {
+          id: monitorId,
+          name: opts.name,
+          type: opts.type,
+          url: opts.url ?? null,
+          interval
+        };
+        if (pushToken) data.pushToken = pushToken;
+        if (tagWarnings.length > 0) data.warnings = tagWarnings;
+        jsonOut(data, tagWarnings.length > 0 ? 1 : 0);
       }
       success(`Monitor "${opts.name}" created (ID: ${monitorId})`);
+      if (pushToken) {
+        console.log(`   Push token: ${source_default.cyan(pushToken)}`);
+        console.log(`   Push URL:   ${source_default.dim(`${config.url}/api/push/${pushToken}`)}`);
+      }
       if (opts.tag.length > 0) {
-        console.log(`   Tags: ${opts.tag.join(", ")}`);
+        const applied = opts.tag.filter((t) => !tagWarnings.some((w) => w.includes(t)));
+        if (applied.length > 0) console.log(`   Tags: ${applied.join(", ")}`);
+      }
+      if (tagWarnings.length > 0) {
+        process.exit(1);
       }
     } catch (err) {
       handleError(err, opts);
@@ -31030,10 +31058,10 @@ ${source_default.dim("Run")} ${source_default.cyan("kuma heartbeat <subcommand> 
     "after",
     `
 ${source_default.dim("Examples:")}
-  ${source_default.cyan("kuma heartbeat view 42")}                  Last 20 heartbeats for monitor 42
-  ${source_default.cyan("kuma heartbeat view 42 --limit 50")}       Last 50 heartbeats
-  ${source_default.cyan("kuma heartbeat view 42 --json")}           Machine-readable output
-  ${source_default.cyan("kuma heartbeat view 42 --json | jq '.data[] | select(.status == 0)'")}   Show failures
+  ${source_default.cyan("kuma heartbeat view 42")}
+  ${source_default.cyan("kuma heartbeat view 42 --limit 50")}
+  ${source_default.cyan("kuma heartbeat view 42 --json")}
+  ${source_default.cyan("kuma heartbeat view 42 --json | jq '.data[] | select(.status == 0)'")}
 `
   ).action(async (monitorId, opts) => {
     const config = getConfig();
@@ -31079,33 +31107,36 @@ ${source_default.dim("Examples:")}
 
 ${source_default.dim("GitHub Actions usage:")}
   ${source_default.cyan("- name: Heartbeat")}
-  ${source_default.cyan("  run: kuma heartbeat send ${{ secrets.RUNNER_PUSH_TOKEN }}")}
+  ${source_default.cyan("  if: always()")}
+  ${source_default.cyan("  run: kuma heartbeat send ${{ secrets.RUNNER_PUSH_TOKEN }} --status ${{ job.status == 'success' && 'up' || 'down' }}")}
 
 ${source_default.dim("Finding your push token:")}
-  Create a "Push" monitor in Kuma UI. The push URL looks like:
+  Create a "Push" monitor in Kuma UI. The push URL is:
   https://kuma.example.com/api/push/<token>
-  Use the <token> part as the argument.
+  Use only the <token> part.
+
+  Or get it from CLI: kuma monitors create --type push --name "my-runner" --json | jq '.data.pushToken'
 `
   ).action(async (pushToken, opts) => {
     const json = isJsonMode(opts);
+    const VALID_STATUSES = ["up", "down", "maintenance"];
+    const statusKey = (opts.status ?? "up").toLowerCase();
+    if (!VALID_STATUSES.includes(statusKey)) {
+      const msg = `Invalid status "${opts.status}". Valid: up, down, maintenance`;
+      if (json) jsonError(msg, EXIT_CODES.GENERAL);
+      console.error(source_default.red(`\u274C ${msg}`));
+      process.exit(EXIT_CODES.GENERAL);
+    }
     let baseUrl = opts.url;
     if (!baseUrl) {
       const config = getConfig();
       if (!config) {
-        const msg = "No --url specified and not logged in. Run: kuma login <url> or use --url";
-        if (json) jsonOut({ ok: false, error: msg });
+        const msg = "No --url specified and not logged in. Run: kuma login <url> or pass --url";
+        if (json) jsonError(msg, EXIT_CODES.AUTH);
         console.error(source_default.red(`\u274C ${msg}`));
         process.exit(EXIT_CODES.AUTH);
       }
       baseUrl = config.url;
-    }
-    const STATUS_MAP = { up: "up", down: "down", maintenance: "maintenance" };
-    const statusKey = (opts.status ?? "up").toLowerCase();
-    if (!(statusKey in STATUS_MAP)) {
-      const msg = `Invalid status "${opts.status}". Valid: up, down, maintenance`;
-      if (json) jsonOut({ ok: false, error: msg });
-      console.error(source_default.red(`\u274C ${msg}`));
-      process.exit(EXIT_CODES.GENERAL);
     }
     const pushUrl = new URL(`${baseUrl.replace(/\/$/, "")}/api/push/${pushToken}`);
     pushUrl.searchParams.set("status", statusKey);
@@ -31117,8 +31148,15 @@ ${source_default.dim("Finding your push token:")}
       });
       if (!res.ok) {
         const body = await res.text().catch(() => "");
-        const msg = `Kuma push failed (HTTP ${res.status}): ${body}`;
-        if (json) jsonOut({ ok: false, error: msg });
+        const msg = `Push failed (HTTP ${res.status}): ${body || res.statusText}`;
+        if (json) jsonError(msg, EXIT_CODES.GENERAL);
+        console.error(source_default.red(`\u274C ${msg}`));
+        process.exit(EXIT_CODES.GENERAL);
+      }
+      const data = await res.json().catch(() => ({ ok: true }));
+      if (data.ok === false) {
+        const msg = data.msg ?? "Kuma rejected the push heartbeat";
+        if (json) jsonError(msg, EXIT_CODES.GENERAL);
         console.error(source_default.red(`\u274C ${msg}`));
         process.exit(EXIT_CODES.GENERAL);
       }
@@ -31128,7 +31166,7 @@ ${source_default.dim("Finding your push token:")}
       success(`Push heartbeat sent (${statusKey}${opts.msg ? ` \u2014 ${opts.msg}` : ""})`);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      if (json) jsonOut({ ok: false, error: msg });
+      if (json) jsonError(msg, EXIT_CODES.CONNECTION);
       console.error(source_default.red(`\u274C ${msg}`));
       process.exit(EXIT_CODES.CONNECTION);
     }
@@ -31516,7 +31554,7 @@ ${source_default.bold("Quick Start:")}
   ${source_default.cyan("kuma login https://kuma.example.com")}   Authenticate (saves session)
   ${source_default.cyan("kuma monitors list")}                    List all monitors + status
   ${source_default.cyan('kuma monitors add --name "My API" --type http --url https://api.example.com')}
-  ${source_default.cyan("kuma heartbeat 42")}                     View recent heartbeats for monitor 42
+  ${source_default.cyan("kuma heartbeat view 42")}                View recent heartbeats for monitor 42
   ${source_default.cyan("kuma logout")}                           Clear saved session
 
 ${source_default.bold("JSON / scripting mode:")}

--- a/src/client.ts
+++ b/src/client.ts
@@ -232,7 +232,16 @@ export class KumaClient {
 
   // BUG-01 fix: addMonitor uses callback, not a separate event
   // BUG-03 fix: include required fields accepted_statuscodes, maxretries, retryInterval
-  async addMonitor(monitor: Partial<Monitor>): Promise<{ id: number }> {
+  async addMonitor(monitor: Partial<Monitor> & { pushToken?: string }): Promise<{ id: number; pushToken?: string }> {
+    // Auto-generate a pushToken for push monitors if not provided.
+    // Kuma stores it on the monitor bean; without this it stays null.
+    const autoToken =
+      monitor.type === "push" && !monitor.pushToken
+        ? Array.from(crypto.getRandomValues(new Uint8Array(24)))
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("")
+        : undefined;
+
     const payload = {
       accepted_statuscodes: ["200-299"],
       maxretries: 1,
@@ -241,6 +250,7 @@ export class KumaClient {
       rabbitmqNodes: [],
       kafkaProducerBrokers: [],
       kafkaProducerSaslOptions: { mechanism: "none" },
+      ...(autoToken ? { pushToken: autoToken } : {}),
       ...monitor,
     };
     return new Promise((resolve, reject) => {
@@ -258,7 +268,11 @@ export class KumaClient {
             reject(new Error(result.msg ?? "Failed to add monitor"));
             return;
           }
-          resolve({ id: result.monitorID! });
+          resolve({
+            id: result.monitorID!,
+            // Return the token we generated so the caller has it immediately
+            pushToken: (payload as { pushToken?: string }).pushToken,
+          });
         }
       );
     });

--- a/src/commands/heartbeat.ts
+++ b/src/commands/heartbeat.ts
@@ -8,6 +8,7 @@ import {
   formatDate,
   isJsonMode,
   jsonOut,
+  jsonError,
   success,
 } from "../utils/output.js";
 import { handleError, requireAuth, EXIT_CODES } from "../utils/errors.js";
@@ -38,10 +39,10 @@ ${chalk.dim("Run")} ${chalk.cyan("kuma heartbeat <subcommand> --help")} ${chalk.
       "after",
       `
 ${chalk.dim("Examples:")}
-  ${chalk.cyan("kuma heartbeat view 42")}                  Last 20 heartbeats for monitor 42
-  ${chalk.cyan("kuma heartbeat view 42 --limit 50")}       Last 50 heartbeats
-  ${chalk.cyan("kuma heartbeat view 42 --json")}           Machine-readable output
-  ${chalk.cyan("kuma heartbeat view 42 --json | jq '.data[] | select(.status == 0)'")}   Show failures
+  ${chalk.cyan("kuma heartbeat view 42")}
+  ${chalk.cyan("kuma heartbeat view 42 --limit 50")}
+  ${chalk.cyan("kuma heartbeat view 42 --json")}
+  ${chalk.cyan("kuma heartbeat view 42 --json | jq '.data[] | select(.status == 0)'")}
 `
     )
     .action(async (monitorId: string, opts: { limit?: string; json?: boolean }) => {
@@ -104,12 +105,15 @@ ${chalk.dim("Examples:")}
 
 ${chalk.dim("GitHub Actions usage:")}
   ${chalk.cyan("- name: Heartbeat")}
-  ${chalk.cyan("  run: kuma heartbeat send \${{ secrets.RUNNER_PUSH_TOKEN }}")}
+  ${chalk.cyan("  if: always()")}
+  ${chalk.cyan("  run: kuma heartbeat send \${{ secrets.RUNNER_PUSH_TOKEN }} --status \${{ job.status == 'success' && 'up' || 'down' }}")}
 
 ${chalk.dim("Finding your push token:")}
-  Create a \"Push\" monitor in Kuma UI. The push URL looks like:
+  Create a "Push" monitor in Kuma UI. The push URL is:
   https://kuma.example.com/api/push/<token>
-  Use the <token> part as the argument.
+  Use only the <token> part.
+
+  Or get it from CLI: kuma monitors create --type push --name "my-runner" --json | jq '.data.pushToken'
 `
     )
     .action(async (pushToken: string, opts: {
@@ -121,26 +125,27 @@ ${chalk.dim("Finding your push token:")}
     }) => {
       const json = isJsonMode(opts);
 
+      // Validate status before doing any network call
+      const VALID_STATUSES = ["up", "down", "maintenance"];
+      const statusKey = (opts.status ?? "up").toLowerCase();
+      if (!VALID_STATUSES.includes(statusKey)) {
+        const msg = `Invalid status "${opts.status}". Valid: up, down, maintenance`;
+        if (json) jsonError(msg, EXIT_CODES.GENERAL);
+        console.error(chalk.red(`❌ ${msg}`));
+        process.exit(EXIT_CODES.GENERAL);
+      }
+
       // Determine base URL
       let baseUrl = opts.url;
       if (!baseUrl) {
         const config = getConfig();
         if (!config) {
-          const msg = "No --url specified and not logged in. Run: kuma login <url> or use --url";
-          if (json) jsonOut({ ok: false, error: msg });
+          const msg = "No --url specified and not logged in. Run: kuma login <url> or pass --url";
+          if (json) jsonError(msg, EXIT_CODES.AUTH);
           console.error(chalk.red(`❌ ${msg}`));
           process.exit(EXIT_CODES.AUTH);
         }
         baseUrl = config.url;
-      }
-
-      const STATUS_MAP: Record<string, string> = { up: "up", down: "down", maintenance: "maintenance" };
-      const statusKey = (opts.status ?? "up").toLowerCase();
-      if (!(statusKey in STATUS_MAP)) {
-        const msg = `Invalid status "${opts.status}". Valid: up, down, maintenance`;
-        if (json) jsonOut({ ok: false, error: msg });
-        console.error(chalk.red(`❌ ${msg}`));
-        process.exit(EXIT_CODES.GENERAL);
       }
 
       // Build the push URL
@@ -156,8 +161,19 @@ ${chalk.dim("Finding your push token:")}
 
         if (!res.ok) {
           const body = await res.text().catch(() => "");
-          const msg = `Kuma push failed (HTTP ${res.status}): ${body}`;
-          if (json) jsonOut({ ok: false, error: msg });
+          const msg = `Push failed (HTTP ${res.status}): ${body || res.statusText}`;
+          if (json) jsonError(msg, EXIT_CODES.GENERAL);
+          console.error(chalk.red(`❌ ${msg}`));
+          process.exit(EXIT_CODES.GENERAL);
+        }
+
+        // Kuma push endpoint returns { ok: boolean, msg?: string }
+        const data = await res.json().catch(() => ({ ok: true })) as { ok?: boolean; msg?: string };
+
+        if (data.ok === false) {
+          // Server returned ok:false inside a 200 response (e.g. invalid token)
+          const msg = data.msg ?? "Kuma rejected the push heartbeat";
+          if (json) jsonError(msg, EXIT_CODES.GENERAL);
           console.error(chalk.red(`❌ ${msg}`));
           process.exit(EXIT_CODES.GENERAL);
         }
@@ -169,7 +185,7 @@ ${chalk.dim("Finding your push token:")}
         success(`Push heartbeat sent (${statusKey}${opts.msg ? ` — ${opts.msg}` : ""})`);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        if (json) jsonOut({ ok: false, error: msg });
+        if (json) jsonError(msg, EXIT_CODES.CONNECTION);
         console.error(chalk.red(`❌ ${msg}`));
         process.exit(EXIT_CODES.CONNECTION);
       }

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -271,21 +271,22 @@ ${chalk.dim("Examples:")}
     .requiredOption("--type <type>", "Monitor type: http, tcp, ping, dns, push, ...")
     .option("--url <url>", "URL or hostname to monitor")
     .option("--interval <seconds>", "Check interval in seconds (default: 60)", "60")
-    .option("--tag <tag>", "Assign a tag by name (repeatable)", collect, [])
+    .option("--tag <tag>", "Assign a tag by name (repeatable — must already exist in Kuma)", collect, [])
     .option("--notification-id <id>", "Assign a notification channel by ID (repeatable)", collectInt, [])
-    .option("--json", "Output as JSON ({ ok, data }) — prints monitor ID to stdout")
+    .option("--json", "Output as JSON ({ ok, data }) — prints monitor ID and pushToken to stdout")
     .addHelpText(
       "after",
       `
 ${chalk.dim("Examples:")}
   ${chalk.cyan("kuma monitors create --type http --name \"habitu.ar\" --url https://habitu.ar")}
   ${chalk.cyan("kuma monitors create --type http --name \"My API\" --url https://api.example.com --tag Production --tag BlackAsteroid")}
-  ${chalk.cyan("kuma monitors create --type push --name \"GH Runner\" --json | jq '.data.id'")}
+  ${chalk.cyan("kuma monitors create --type push --name \"GH Runner\" --json | jq '.data.pushToken'")}
   ${chalk.cyan("kuma monitors create --type tcp --name \"DB\" --url db.host:5432 --interval 30 --notification-id 1")}
 
-${chalk.dim("Pipeline usage:")}
-  ${chalk.cyan("MONITOR_ID=$(kuma monitors create --type http --name \"svc\" --url https://svc.example.com --json | jq '.data.id')")}
-  ${chalk.cyan("kuma monitors set-notification $MONITOR_ID --notification-id $NOTIF_ID")}
+${chalk.dim("Full pipeline (deploy → monitor → heartbeat):")}
+  ${chalk.cyan("RESULT=\$(kuma monitors create --type push --name \"runner\" --json)")}
+  ${chalk.cyan("PUSH_TOKEN=\$(echo \$RESULT | jq -r '.data.pushToken')")}
+  ${chalk.cyan("kuma heartbeat send \$PUSH_TOKEN --msg \"Alive\"")}
 `
     )
     .action(async (opts: {
@@ -319,6 +320,12 @@ ${chalk.dim("Pipeline usage:")}
           interval,
         });
         const monitorId = result.id;
+        // pushToken is returned directly from addMonitor for push monitors
+        // (auto-generated in the client before sending to Kuma)
+        let pushToken: string | null = result.pushToken ?? null;
+
+        // BUG-02 fix: track tag warnings explicitly so JSON consumers can see them
+        const tagWarnings: string[] = [];
 
         // Assign tags if specified
         if (opts.tag.length > 0) {
@@ -328,8 +335,10 @@ ${chalk.dim("Pipeline usage:")}
           for (const tagName of opts.tag) {
             const found = tagMap.get(tagName.toLowerCase());
             if (!found) {
+              const warn = `Tag "${tagName}" not found — skipping. Create it in the Kuma UI first.`;
+              tagWarnings.push(warn);
               if (!json) {
-                error(`Tag "${tagName}" not found — skipping (create it in the Kuma UI first)`);
+                console.warn(chalk.yellow(`⚠️  ${warn}`));
               }
               continue;
             }
@@ -348,12 +357,31 @@ ${chalk.dim("Pipeline usage:")}
         client.disconnect();
 
         if (json) {
-          jsonOut({ id: monitorId, name: opts.name, type: opts.type, url: opts.url, interval });
+          const data: Record<string, unknown> = {
+            id: monitorId,
+            name: opts.name,
+            type: opts.type,
+            url: opts.url ?? null,
+            interval,
+          };
+          if (pushToken) data.pushToken = pushToken;
+          if (tagWarnings.length > 0) data.warnings = tagWarnings;
+          // BUG-02: exit 1 when warnings exist so pipelines can detect the issue
+          jsonOut(data, tagWarnings.length > 0 ? 1 : 0);
         }
 
         success(`Monitor "${opts.name}" created (ID: ${monitorId})`);
+        if (pushToken) {
+          console.log(`   Push token: ${chalk.cyan(pushToken)}`);
+          console.log(`   Push URL:   ${chalk.dim(`${config!.url}/api/push/${pushToken}`)}`);
+        }
         if (opts.tag.length > 0) {
-          console.log(`   Tags: ${opts.tag.join(", ")}`);
+          const applied = opts.tag.filter((t) => !tagWarnings.some((w) => w.includes(t)));
+          if (applied.length > 0) console.log(`   Tags: ${applied.join(", ")}`);
+        }
+        // BUG-02: exit 1 if any tags were not found — makes pipeline failures visible
+        if (tagWarnings.length > 0) {
+          process.exit(1);
         }
       } catch (err) {
         handleError(err, opts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ ${chalk.bold("Quick Start:")}
   ${chalk.cyan("kuma login https://kuma.example.com")}   Authenticate (saves session)
   ${chalk.cyan("kuma monitors list")}                    List all monitors + status
   ${chalk.cyan("kuma monitors add --name \"My API\" --type http --url https://api.example.com")}
-  ${chalk.cyan("kuma heartbeat 42")}                     View recent heartbeats for monitor 42
+  ${chalk.cyan("kuma heartbeat view 42")}                View recent heartbeats for monitor 42
   ${chalk.cyan("kuma logout")}                           Clear saved session
 
 ${chalk.bold("JSON / scripting mode:")}

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -91,9 +91,9 @@ export function isJsonMode(opts?: { json?: boolean }): boolean {
  * Emit a successful JSON response to stdout and exit 0.
  * Shape: `{ "ok": true, "data": <payload> }`
  */
-export function jsonOut(data: unknown): never {
+export function jsonOut(data: unknown, exitCode = 0): never {
   console.log(JSON.stringify({ ok: true, data }, null, 2));
-  process.exit(0);
+  process.exit(exitCode);
 }
 
 /**


### PR DESCRIPTION
Closes #24, #26, #28

## Issue #24 — `kuma monitors create` (non-interactive)

Fully non-interactive monitor creation for CI/CD pipelines.

```bash
kuma monitors create \
  --type http --name "habitu.ar" --url https://habitu.ar \
  --tag Production --tag BlackAsteroid \
  --notification-id 1

# Pipeline: capture ID for next step
MONITOR_ID=$(kuma monitors create --type http --name "svc" --url https://svc.example.com --json | jq '.data.id')
kuma monitors set-notification $MONITOR_ID --notification-id $NOTIF_ID
```

- `--tag` (repeatable) — resolves tag names → IDs and assigns them
- `--notification-id` (repeatable) — assigns notification channels
- `--json` outputs `{ id, name, type, url, interval }`
- Fixed `addMonitor` payload with required `conditions`/`rabbitmqNodes`/`kafkaProducerBrokers` fields (Kuma NOT NULL constraints)

---

## Issue #26 — `kuma monitors bulk-pause / bulk-resume`

Maintenance window pattern in two commands:

```bash
kuma monitors bulk-pause --tag Production
./deploy.sh
kuma monitors bulk-resume --tag Production
```

- `--tag` and/or `--status` filters
- `--dry-run`: preview without touching anything
- `--json`: `{ affected, failed, results[] }` for pipeline error handling
- Non-zero exit if any operation fails (pipeline-safe)

**Dry-run tested against production:**
```
Dry run — would pause 14 monitor(s):
   1 habitu.ar
   2 factura.blackasteroid.com.ar
   ...
```

---

## Issue #28 — `kuma heartbeat send <push-token>`

Push heartbeat from scripts and GitHub Actions. No auth needed — direct HTTP to the push endpoint.

```yaml
# GitHub Actions
- name: Heartbeat to Kuma
  run: kuma heartbeat send ${{ secrets.RUNNER_PUSH_TOKEN }}
```

```bash
kuma heartbeat send abc123 --status down --msg "Deploy failed"
kuma heartbeat send abc123 --msg "Deploy complete" --ping 42
```

---

## ⚠️ Minor breaking change

`kuma heartbeat <id>` is now `kuma heartbeat view <id>` — the `heartbeat` command became a subcommand group to accommodate both `view` and `send`. Old usage returns an error with a clear message.