### PR TITLE
docs: add agent usage section + v1.2.0 commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kuma-cli
 
-> CLI for managing [Uptime Kuma](https://github.com/louislam/uptime-kuma) via its native Socket.IO API. No more clicking through the web panel — manage monitors, status pages, and heartbeats directly from your terminal.
+> CLI for managing [Uptime Kuma](https://github.com/louislam/uptime-kuma) via its native Socket.IO API. No more clicking through the web panel — manage monitors, status pages, and heartbeats from your terminal.
 
 ## Install
 
@@ -14,7 +14,7 @@ Or use without installing:
 npx @blackasteroid/kuma-cli login https://kuma.example.com
 ```
 
-## Quick Start
+## Quick start
 
 ```bash
 # 1. Authenticate
@@ -23,8 +23,8 @@ kuma login https://kuma.example.com
 # 2. List monitors
 kuma monitors list
 
-# 3. Add a monitor
-kuma monitors add --name "My API" --type http --url https://api.example.com
+# 3. Create a monitor
+kuma monitors create --name "My API" --type http --url https://api.example.com
 ```
 
 ## Commands
@@ -43,45 +43,89 @@ kuma monitors add --name "My API" --type http --url https://api.example.com
 |---------|-------------|
 | `kuma monitors list` | List all monitors with status + uptime |
 | `kuma monitors list --json` | Output raw JSON (for scripting) |
+| `kuma monitors list --status down --json` | Filter by status |
+| `kuma monitors list --tag <tag> --json` | Filter by tag |
 | `kuma monitors add` | Add a monitor interactively |
 | `kuma monitors add --name <n> --type http --url <url>` | Add non-interactively |
+| `kuma monitors create --type http --name <n> --url <url>` | Create monitor non-interactively (pipeline-safe) |
+| `kuma monitors create --type push --name <n> --json` | Create push monitor, returns pushToken |
 | `kuma monitors update <id>` | Update name/url/interval of a monitor |
 | `kuma monitors delete <id>` | Delete a monitor (with confirmation) |
 | `kuma monitors delete <id> --force` | Delete without confirmation prompt |
 | `kuma monitors pause <id>` | Pause a monitor |
 | `kuma monitors resume <id>` | Resume a paused monitor |
-
-#### `monitors add` flags
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--name <name>` | Monitor name | (prompted) |
-| `--type <type>` | Monitor type: `http`, `tcp`, `ping`, `dns`, `push`, ... | (prompted) |
-| `--url <url>` | URL or hostname to monitor | (prompted) |
-| `--interval <seconds>` | Check interval | `60` |
-
-#### `monitors update` flags
-
-| Flag | Description |
-|------|-------------|
-| `--name <name>` | New monitor name |
-| `--url <url>` | New URL or hostname |
-| `--interval <seconds>` | New check interval |
+| `kuma monitors bulk-pause --tag <tag>` | Pause all monitors matching tag |
+| `kuma monitors bulk-pause --tag <tag> --dry-run` | Preview without touching anything |
+| `kuma monitors bulk-resume --tag <tag>` | Resume all monitors matching tag |
+| `kuma monitors set-notification <id> --notification-id <id>` | Assign notification to monitor |
 
 ### Heartbeats
 
 | Command | Description |
 |---------|-------------|
-| `kuma heartbeat <monitor-id>` | View last 20 heartbeats for a monitor |
-| `kuma heartbeat <monitor-id> --limit 50` | Show last N heartbeats |
-| `kuma heartbeat <monitor-id> --json` | Output raw JSON |
+| `kuma heartbeat view <monitor-id>` | View last 20 heartbeats |
+| `kuma heartbeat view <monitor-id> --limit 50` | Show last N heartbeats |
+| `kuma heartbeat view <monitor-id> --json` | Output raw JSON |
+| `kuma heartbeat send <push-token>` | Send push heartbeat (no auth needed) |
+| `kuma heartbeat send <push-token> --status down --msg "text"` | Send with status/message |
 
-### Status Pages
+### Notifications
+
+| Command | Description |
+|---------|-------------|
+| `kuma notifications list` | List all notification channels |
+| `kuma notifications create --type discord --name <n> --url <webhook>` | Create Discord notification channel |
+
+### Status pages
 
 | Command | Description |
 |---------|-------------|
 | `kuma status-pages list` | List all status pages |
 | `kuma status-pages list --json` | Output raw JSON |
+
+## Using with AI agents
+
+kuma-cli works well in agent and automation contexts. Every command supports `--json` output and exits non-zero on errors, so you can parse results reliably and short-circuit on failure.
+
+Set `KUMA_JSON=1` to force JSON output on all commands — useful when you don't control the call site.
+
+**Check what's down:**
+```bash
+kuma monitors list --status down --json
+```
+
+**Pause/resume around a deploy:**
+```bash
+kuma monitors bulk-pause --tag Production --dry-run   # preview first
+kuma monitors bulk-pause --tag Production
+./deploy.sh
+kuma monitors bulk-resume --tag Production
+```
+
+**Create a monitor and wire up a notification in one shot:**
+```bash
+MONITOR_ID=$(kuma monitors create --type http --name "my-service" \
+  --url https://my-service.com --tag Production --json | jq -r '.data.id')
+kuma monitors set-notification $MONITOR_ID --notification-id 1
+```
+
+**Push monitor for a GitHub Actions runner:**
+```bash
+# Create the monitor, capture the token
+TOKEN=$(kuma monitors create --type push --name "runner-aang" --json | jq -r '.data.pushToken')
+
+# In the workflow:
+- name: Heartbeat
+  run: kuma heartbeat send ${{ secrets.RUNNER_PUSH_TOKEN }}
+```
+
+**Connect a notification channel to all production monitors:**
+```bash
+NOTIF_ID=$(kuma notifications create --type discord --name "alerts" \
+  --url $WEBHOOK --json | jq -r '.data.id')
+kuma monitors list --tag Production --json | jq -r '.[].id' | \
+  xargs -I{} kuma monitors set-notification {} --notification-id $NOTIF_ID
+```
 
 ## Config
 


### PR DESCRIPTION
Updates README for v1.2.0:
- Add 'Using with AI agents' section with 5 practical patterns
- Add new commands: monitors create, bulk-pause/resume, heartbeat send/view, notifications
- Update Quick Start to use monitors create instead of add
- Humanized prose throughout