### PR TITLE
fix: security hardening — Gerard's review findings

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in kuma-cli, **do not open a public GitHub issue**.
+
+Please report it privately:
+
+- **Email:** security@blackasteroid.com.ar
+- **Response time:** We aim to acknowledge within 48 hours and provide a fix or mitigation within 7 days for critical issues.
+
+Include:
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes (optional)
+
+We will credit you in the release notes unless you prefer to remain anonymous.
+
+## Supported Versions
+
+Only the latest published version on npm is actively supported. Please update before reporting.
+
+```bash
+npm install -g @blackasteroid/kuma-cli@latest
+```
+
+## Known Security Considerations
+
+### Credential handling
+
+- **Session tokens** are stored in plaintext at `~/.config/kuma-cli-nodejs/config.json` with `0600` permissions (readable only by the owning user). OS-level keychain integration is planned for a future release.
+
+- **Notification secrets** (webhook URLs, bot tokens) should always be passed via environment variables, never as literal flag values. Literal values appear in shell history (`~/.zsh_history`, `~/.bash_history`) and process listings (`ps aux`).
+
+  ✅ Correct:
+  ```bash
+  export DISCORD_WEBHOOK=https://discord.com/api/webhooks/...
+  kuma notifications create --type discord --name "Alerts" --discord-webhook '$DISCORD_WEBHOOK'
+  ```
+
+  ❌ Avoid:
+  ```bash
+  kuma notifications create --type discord --name "Alerts" --discord-webhook https://discord.com/api/webhooks/TOKEN
+  ```
+
+### Network security
+
+- The CLI will warn when connecting to a Kuma instance over plain HTTP (`http://`). Always use HTTPS in production environments — credentials and session tokens are transmitted over the WebSocket connection.
+
+### Push tokens
+
+- Push monitor tokens are cryptographically random (48 hex chars from `crypto.getRandomValues`). Keep them secret; anyone with the token can send heartbeats.
+
+### Upgrade integrity
+
+- `kuma upgrade` installs the specific version confirmed from GitHub Releases (e.g., `@blackasteroid/kuma-cli@1.2.0`) rather than `@latest` to reduce exposure to supply chain attacks on the npm registry.

--- a/dist/index.js
+++ b/dist/index.js
@@ -30366,6 +30366,17 @@ ${source_default.dim("Notes:")}
     const json = isJsonMode(opts);
     try {
       const normalizedUrl = url2.replace(/\/$/, "");
+      if (!normalizedUrl.startsWith("https://")) {
+        if (json) {
+          console.log(JSON.stringify({
+            warning: "Connecting over HTTP. Credentials will be transmitted in cleartext. Use HTTPS in production."
+          }));
+        } else {
+          console.warn(source_default.yellow(
+            "\u26A0\uFE0F  Warning: connecting over HTTP. Your credentials will be sent in cleartext.\n   Use https:// in production environments."
+          ));
+        }
+      }
       const answers = await prompt([
         {
           type: "input",
@@ -31067,9 +31078,13 @@ ${source_default.dim("Examples:")}
     const config = getConfig();
     if (!config) requireAuth(opts);
     const json = isJsonMode(opts);
+    const parsedMonitorId = parseInt(monitorId, 10);
+    if (isNaN(parsedMonitorId) || parsedMonitorId <= 0) {
+      handleError(new Error(`Invalid monitor ID: "${monitorId}". Must be a positive integer.`), opts);
+    }
     try {
       const client = await createAuthenticatedClient(config.url, config.token);
-      const heartbeats = await client.getHeartbeatList(parseInt(monitorId, 10));
+      const heartbeats = await client.getHeartbeatList(parsedMonitorId);
       client.disconnect();
       const limit = parseInt(opts.limit ?? "20", 10);
       const recent = heartbeats.slice(-limit).reverse();
@@ -31119,6 +31134,12 @@ ${source_default.dim("Finding your push token:")}
 `
   ).action(async (pushToken, opts) => {
     const json = isJsonMode(opts);
+    if (!/^[a-zA-Z0-9_-]+$/.test(pushToken)) {
+      const msg = `Invalid push token format. Tokens must contain only alphanumeric characters, hyphens, and underscores.`;
+      if (json) jsonError(msg, EXIT_CODES.GENERAL);
+      console.error(source_default.red(`\u274C ${msg}`));
+      process.exit(EXIT_CODES.GENERAL);
+    }
     const VALID_STATUSES = ["up", "down", "maintenance"];
     const statusKey = (opts.status ?? "up").toLowerCase();
     if (!VALID_STATUSES.includes(statusKey)) {
@@ -31324,7 +31345,7 @@ ${source_default.bold(`Upgrading kuma-cli`)} ${source_default.dim(`v${current}`)
       );
     }
     try {
-      (0, import_child_process.execSync)("npm install -g @blackasteroid/kuma-cli@latest", {
+      (0, import_child_process.execSync)(`npm install -g @blackasteroid/kuma-cli@${latest}`, {
         stdio: json ? "pipe" : "inherit"
       });
     } catch (err) {
@@ -31357,6 +31378,27 @@ ${source_default.bold(`Upgrading kuma-cli`)} ${source_default.dim(`v${current}`)
 }
 
 // src/commands/notifications.ts
+function resolveSecret(value2) {
+  if (value2 === void 0) return void 0;
+  if (value2.startsWith("$")) {
+    const varName = value2.slice(1);
+    const resolved = process.env[varName];
+    if (!resolved) {
+      return void 0;
+    }
+    return resolved;
+  }
+  if (value2 === "-") {
+    try {
+      const buf = Buffer.alloc(4096);
+      const n = require("fs").readSync(0, buf, 0, buf.length, null);
+      return buf.toString("utf8", 0, n).trim();
+    } catch {
+      return void 0;
+    }
+  }
+  return value2;
+}
 function notificationsCommand(program3) {
   const notifications = program3.command("notifications").description("Manage notification channels (Discord, Telegram, webhook, ...)").addHelpText(
     "after",
@@ -31423,14 +31465,18 @@ ${list.length} notification channel(s)`);
       handleError(err, opts);
     }
   });
-  notifications.command("create").description("Create a new notification channel").requiredOption("--type <type>", "Notification type: discord, telegram, slack, webhook, ...").requiredOption("--name <name>", "Friendly name for this notification channel").option("--discord-webhook <url>", "Discord webhook URL (required for --type discord)").option("--discord-username <name>", "Discord bot display name (optional)").option("--telegram-token <token>", "Telegram bot token (required for --type telegram)").option("--telegram-chat-id <id>", "Telegram chat ID (required for --type telegram)").option("--slack-webhook <url>", "Slack webhook URL (required for --type slack)").option("--webhook-url <url>", "Webhook URL (required for --type webhook)").option("--webhook-content-type <type>", "Webhook content type (default: application/json)", "application/json").option("--default", "Enable this notification by default on all new monitors").option("--apply-existing", "Apply this notification to all existing monitors immediately").option("--json", "Output as JSON ({ ok, data })").addHelpText(
+  notifications.command("create").description("Create a new notification channel").requiredOption("--type <type>", "Notification type: discord, telegram, slack, webhook, ...").requiredOption("--name <name>", "Friendly name for this notification channel").option("--discord-webhook <url|$VAR>", "Discord webhook URL \u2014 pass value or env var name like '$DISCORD_WEBHOOK'").option("--discord-username <name>", "Discord bot display name (optional)").option("--telegram-token <token|$VAR>", "Telegram bot token \u2014 pass value or env var name like '$TELEGRAM_TOKEN'").option("--telegram-chat-id <id>", "Telegram chat ID (required for --type telegram)").option("--slack-webhook <url|$VAR>", "Slack webhook URL \u2014 pass value or env var name like '$SLACK_WEBHOOK'").option("--webhook-url <url|$VAR>", "Webhook URL \u2014 pass value or env var name like '$WEBHOOK_URL'").option("--webhook-content-type <type>", "Webhook content type (default: application/json)", "application/json").option("--default", "Enable this notification by default on all new monitors").option("--apply-existing", "Apply this notification to all existing monitors immediately").option("--json", "Output as JSON ({ ok, data })").addHelpText(
     "after",
     `
 ${source_default.dim("Examples:")}
-  ${source_default.cyan('kuma notifications create --type discord --name "Alerts" --discord-webhook https://discord.com/api/webhooks/...')}
-  ${source_default.cyan('kuma notifications create --type telegram --name "TG" --telegram-token 123:ABC --telegram-chat-id -100...')}
-  ${source_default.cyan('kuma notifications create --type webhook --name "My Hook" --webhook-url https://example.com/hook')}
-  ${source_default.cyan('kuma notifications create --type discord --name "Default" --discord-webhook $URL --default --apply-existing')}
+  ${source_default.cyan(`kuma notifications create --type discord --name "Alerts" --discord-webhook '$DISCORD_WEBHOOK'`)}
+  ${source_default.cyan(`kuma notifications create --type telegram --name "TG" --telegram-token '$TELEGRAM_TOKEN' --telegram-chat-id -100...`)}
+  ${source_default.cyan(`kuma notifications create --type webhook --name "My Hook" --webhook-url '$WEBHOOK_URL'`)}
+  ${source_default.cyan(`kuma notifications create --type discord --name "Default" --discord-webhook '$DISCORD_WEBHOOK' --default --apply-existing`)}
+
+${source_default.dim("\u26A0\uFE0F  Security: never pass secrets as literal flag values \u2014 use env vars:")}
+  ${source_default.cyan("export DISCORD_WEBHOOK=https://discord.com/api/webhooks/...")}
+  ${source_default.cyan(`kuma notifications create --type discord --name "Alerts" --discord-webhook '\\$DISCORD_WEBHOOK'`)}
 
 ${source_default.dim("Supported types:")}
   discord, telegram, slack, webhook, gotify, ntfy, pushover, matrix, mattermost, teams ...
@@ -31447,32 +31493,36 @@ ${source_default.dim("Supported types:")}
       active: true,
       applyExisting: opts.applyExisting ?? false
     };
+    const discordWebhook = resolveSecret(opts.discordWebhook);
+    const telegramToken = resolveSecret(opts.telegramToken);
+    const slackWebhook = resolveSecret(opts.slackWebhook);
+    const webhookUrl = resolveSecret(opts.webhookUrl);
     switch (opts.type.toLowerCase()) {
       case "discord":
-        if (!opts.discordWebhook) {
-          handleError(new Error("--discord-webhook is required for --type discord"), opts);
+        if (!discordWebhook) {
+          handleError(new Error("--discord-webhook is required for --type discord (pass value or '$ENV_VAR_NAME')"), opts);
         }
-        payload.discordWebhookUrl = opts.discordWebhook;
+        payload.discordWebhookUrl = discordWebhook;
         if (opts.discordUsername) payload.discordUsername = opts.discordUsername;
         break;
       case "telegram":
-        if (!opts.telegramToken || !opts.telegramChatId) {
+        if (!telegramToken || !opts.telegramChatId) {
           handleError(new Error("--telegram-token and --telegram-chat-id are required for --type telegram"), opts);
         }
-        payload.telegramBotToken = opts.telegramToken;
+        payload.telegramBotToken = telegramToken;
         payload.telegramChatID = opts.telegramChatId;
         break;
       case "slack":
-        if (!opts.slackWebhook) {
-          handleError(new Error("--slack-webhook is required for --type slack"), opts);
+        if (!slackWebhook) {
+          handleError(new Error("--slack-webhook is required for --type slack (pass value or '$ENV_VAR_NAME')"), opts);
         }
-        payload.slackwebhookURL = opts.slackWebhook;
+        payload.slackwebhookURL = slackWebhook;
         break;
       case "webhook":
-        if (!opts.webhookUrl) {
-          handleError(new Error("--webhook-url is required for --type webhook"), opts);
+        if (!webhookUrl) {
+          handleError(new Error("--webhook-url is required for --type webhook (pass value or '$ENV_VAR_NAME')"), opts);
         }
-        payload.webhookURL = opts.webhookUrl;
+        payload.webhookURL = webhookUrl;
         payload.webhookContentType = opts.webhookContentType ?? "application/json";
         break;
       default:
@@ -31508,8 +31558,8 @@ ${source_default.dim("Examples:")}
     if (!config) requireAuth(opts);
     const json = isJsonMode(opts);
     const notifId = parseInt(id, 10);
-    if (isNaN(notifId)) {
-      handleError(new Error(`Invalid notification ID: ${id}`), opts);
+    if (isNaN(notifId) || notifId <= 0) {
+      handleError(new Error(`Invalid notification ID: "${id}". Must be a positive integer.`), opts);
     }
     if (!opts.force && !json) {
       const enquirer3 = await Promise.resolve().then(() => __toESM(require_enquirer()));

--- a/src/commands/heartbeat.ts
+++ b/src/commands/heartbeat.ts
@@ -51,9 +51,14 @@ ${chalk.dim("Examples:")}
 
       const json = isJsonMode(opts);
 
+      const parsedMonitorId = parseInt(monitorId, 10);
+      if (isNaN(parsedMonitorId) || parsedMonitorId <= 0) {
+        handleError(new Error(`Invalid monitor ID: "${monitorId}". Must be a positive integer.`), opts);
+      }
+
       try {
         const client = await createAuthenticatedClient(config!.url, config!.token);
-        const heartbeats = await client.getHeartbeatList(parseInt(monitorId, 10));
+        const heartbeats = await client.getHeartbeatList(parsedMonitorId);
         client.disconnect();
 
         const limit = parseInt(opts.limit ?? "20", 10);
@@ -124,6 +129,15 @@ ${chalk.dim("Finding your push token:")}
       json?: boolean;
     }) => {
       const json = isJsonMode(opts);
+
+      // Fix #3: Validate pushToken to prevent path traversal / URL injection.
+      // Kuma generates tokens as hex strings; reject anything else.
+      if (!/^[a-zA-Z0-9_-]+$/.test(pushToken)) {
+        const msg = `Invalid push token format. Tokens must contain only alphanumeric characters, hyphens, and underscores.`;
+        if (json) jsonError(msg, EXIT_CODES.GENERAL);
+        console.error(chalk.red(`❌ ${msg}`));
+        process.exit(EXIT_CODES.GENERAL);
+      }
 
       // Validate status before doing any network call
       const VALID_STATUSES = ["up", "down", "maintenance"];

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -34,6 +34,21 @@ ${chalk.dim("Notes:")}
         // Normalize URL
         const normalizedUrl = url.replace(/\/$/, "");
 
+        // Fix #2: Warn when connecting over plain HTTP — credentials will be in cleartext
+        if (!normalizedUrl.startsWith("https://")) {
+          if (json) {
+            // In JSON mode, surface as a warning but don't block — caller decides
+            console.log(JSON.stringify({
+              warning: "Connecting over HTTP. Credentials will be transmitted in cleartext. Use HTTPS in production."
+            }));
+          } else {
+            console.warn(chalk.yellow(
+              "⚠️  Warning: connecting over HTTP. Your credentials will be sent in cleartext.\n" +
+              "   Use https:// in production environments."
+            ));
+          }
+        }
+
         const answers = await prompt([
           {
             type: "input",

--- a/src/commands/notifications.ts
+++ b/src/commands/notifications.ts
@@ -5,6 +5,44 @@ import { getConfig } from "../config.js";
 import { createTable, isJsonMode, jsonOut, success, error } from "../utils/output.js";
 import { handleError, requireAuth } from "../utils/errors.js";
 
+/**
+ * Security fix #1: Resolve a flag value from the environment if it looks like an env var.
+ * Supports two safe patterns:
+ *   - "$VAR_NAME" → reads process.env.VAR_NAME
+ *   - "-"         → reads from stdin (first line)
+ *
+ * This prevents webhook URLs and tokens from appearing in shell history, ps aux output,
+ * and CI/CD logs. Users should pass secrets via env vars:
+ *   DISCORD_WEBHOOK=https://... kuma notifications create --type discord --discord-webhook '$DISCORD_WEBHOOK'
+ */
+function resolveSecret(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+
+  // $VAR_NAME — read from environment
+  if (value.startsWith("$")) {
+    const varName = value.slice(1);
+    const resolved = process.env[varName];
+    if (!resolved) {
+      // Don't throw here — let the per-type validation handle "missing required field"
+      return undefined;
+    }
+    return resolved;
+  }
+
+  // "-" — read from stdin (blocks until newline)
+  if (value === "-") {
+    try {
+      const buf = Buffer.alloc(4096);
+      const n = require("fs").readSync(0, buf, 0, buf.length, null);
+      return buf.toString("utf8", 0, n).trim();
+    } catch {
+      return undefined;
+    }
+  }
+
+  return value;
+}
+
 export function notificationsCommand(program: Command): void {
   const notifications = program
     .command("notifications")
@@ -96,15 +134,15 @@ ${chalk.dim("Examples:")}
     .requiredOption("--type <type>", "Notification type: discord, telegram, slack, webhook, ...")
     .requiredOption("--name <name>", "Friendly name for this notification channel")
     // Discord
-    .option("--discord-webhook <url>", "Discord webhook URL (required for --type discord)")
+    .option("--discord-webhook <url|$VAR>", "Discord webhook URL — pass value or env var name like '$DISCORD_WEBHOOK'")
     .option("--discord-username <name>", "Discord bot display name (optional)")
     // Telegram
-    .option("--telegram-token <token>", "Telegram bot token (required for --type telegram)")
+    .option("--telegram-token <token|$VAR>", "Telegram bot token — pass value or env var name like '$TELEGRAM_TOKEN'")
     .option("--telegram-chat-id <id>", "Telegram chat ID (required for --type telegram)")
     // Slack
-    .option("--slack-webhook <url>", "Slack webhook URL (required for --type slack)")
+    .option("--slack-webhook <url|$VAR>", "Slack webhook URL — pass value or env var name like '$SLACK_WEBHOOK'")
     // Generic webhook
-    .option("--webhook-url <url>", "Webhook URL (required for --type webhook)")
+    .option("--webhook-url <url|$VAR>", "Webhook URL — pass value or env var name like '$WEBHOOK_URL'")
     .option("--webhook-content-type <type>", "Webhook content type (default: application/json)", "application/json")
     // Common flags
     .option("--default", "Enable this notification by default on all new monitors")
@@ -114,10 +152,14 @@ ${chalk.dim("Examples:")}
       "after",
       `
 ${chalk.dim("Examples:")}
-  ${chalk.cyan("kuma notifications create --type discord --name \"Alerts\" --discord-webhook https://discord.com/api/webhooks/...")}
-  ${chalk.cyan("kuma notifications create --type telegram --name \"TG\" --telegram-token 123:ABC --telegram-chat-id -100...")}
-  ${chalk.cyan("kuma notifications create --type webhook --name \"My Hook\" --webhook-url https://example.com/hook")}
-  ${chalk.cyan("kuma notifications create --type discord --name \"Default\" --discord-webhook $URL --default --apply-existing")}
+  ${chalk.cyan("kuma notifications create --type discord --name \"Alerts\" --discord-webhook '$DISCORD_WEBHOOK'")}
+  ${chalk.cyan("kuma notifications create --type telegram --name \"TG\" --telegram-token '$TELEGRAM_TOKEN' --telegram-chat-id -100...")}
+  ${chalk.cyan("kuma notifications create --type webhook --name \"My Hook\" --webhook-url '$WEBHOOK_URL'")}
+  ${chalk.cyan("kuma notifications create --type discord --name \"Default\" --discord-webhook '$DISCORD_WEBHOOK' --default --apply-existing")}
+
+${chalk.dim("⚠️  Security: never pass secrets as literal flag values — use env vars:")}
+  ${chalk.cyan("export DISCORD_WEBHOOK=https://discord.com/api/webhooks/...")}
+  ${chalk.cyan("kuma notifications create --type discord --name \"Alerts\" --discord-webhook '\\$DISCORD_WEBHOOK'")}
 
 ${chalk.dim("Supported types:")}
   discord, telegram, slack, webhook, gotify, ntfy, pushover, matrix, mattermost, teams ...
@@ -153,35 +195,41 @@ ${chalk.dim("Supported types:")}
       };
 
       // Attach provider-specific fields
+      // Fix #1: resolve env var references for all secret/credential flags
+      const discordWebhook = resolveSecret(opts.discordWebhook);
+      const telegramToken = resolveSecret(opts.telegramToken);
+      const slackWebhook = resolveSecret(opts.slackWebhook);
+      const webhookUrl = resolveSecret(opts.webhookUrl);
+
       switch (opts.type.toLowerCase()) {
         case "discord":
-          if (!opts.discordWebhook) {
-            handleError(new Error("--discord-webhook is required for --type discord"), opts);
+          if (!discordWebhook) {
+            handleError(new Error("--discord-webhook is required for --type discord (pass value or '$ENV_VAR_NAME')"), opts);
           }
-          payload.discordWebhookUrl = opts.discordWebhook;
+          payload.discordWebhookUrl = discordWebhook;
           if (opts.discordUsername) payload.discordUsername = opts.discordUsername;
           break;
 
         case "telegram":
-          if (!opts.telegramToken || !opts.telegramChatId) {
+          if (!telegramToken || !opts.telegramChatId) {
             handleError(new Error("--telegram-token and --telegram-chat-id are required for --type telegram"), opts);
           }
-          payload.telegramBotToken = opts.telegramToken;
+          payload.telegramBotToken = telegramToken;
           payload.telegramChatID = opts.telegramChatId;
           break;
 
         case "slack":
-          if (!opts.slackWebhook) {
-            handleError(new Error("--slack-webhook is required for --type slack"), opts);
+          if (!slackWebhook) {
+            handleError(new Error("--slack-webhook is required for --type slack (pass value or '$ENV_VAR_NAME')"), opts);
           }
-          payload.slackwebhookURL = opts.slackWebhook;
+          payload.slackwebhookURL = slackWebhook;
           break;
 
         case "webhook":
-          if (!opts.webhookUrl) {
-            handleError(new Error("--webhook-url is required for --type webhook"), opts);
+          if (!webhookUrl) {
+            handleError(new Error("--webhook-url is required for --type webhook (pass value or '$ENV_VAR_NAME')"), opts);
           }
-          payload.webhookURL = opts.webhookUrl;
+          payload.webhookURL = webhookUrl;
           payload.webhookContentType = opts.webhookContentType ?? "application/json";
           break;
 
@@ -233,8 +281,8 @@ ${chalk.dim("Examples:")}
       const json = isJsonMode(opts);
       const notifId = parseInt(id, 10);
 
-      if (isNaN(notifId)) {
-        handleError(new Error(`Invalid notification ID: ${id}`), opts);
+      if (isNaN(notifId) || notifId <= 0) {
+        handleError(new Error(`Invalid notification ID: "${id}". Must be a positive integer.`), opts);
       }
 
       if (!opts.force && !json) {

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -139,7 +139,11 @@ ${chalk.dim("Examples:")}
       }
 
       try {
-        execSync("npm install -g @blackasteroid/kuma-cli@latest", {
+        // Fix #5: Pin to the specific version confirmed from GitHub Releases
+        // instead of "latest" to reduce supply-chain attack surface.
+        // If the npm registry were compromised between the GitHub check and this
+        // install, a pinned version installs the exact artifact we verified.
+        execSync(`npm install -g @blackasteroid/kuma-cli@${latest}`, {
           stdio: json ? "pipe" : "inherit",
         });
       } catch (err: unknown) {


### PR DESCRIPTION
Addresses all HIGH/MEDIUM/LOW findings from Gerard's security review.

## 🟠 HIGH #1 — Secrets in CLI args (shell history / ps aux leak)

Added `resolveSecret()` to `notifications.ts`. When a flag value starts with `$VAR_NAME`, it reads from `process.env` instead of using the literal value. Falls back to literal if not an env var reference. Stdin (`-`) also supported.

```bash
# Safe — token never appears in shell history
export DISCORD_WEBHOOK=https://discord.com/api/webhooks/TOKEN
kuma notifications create --type discord --name "Alerts" --discord-webhook '$DISCORD_WEBHOOK'
```

All credential flags updated: `--discord-webhook`, `--telegram-token`, `--slack-webhook`, `--webhook-url`. Help text includes security guidance.

---

## 🟠 HIGH #2 — No HTTPS enforcement

`login.ts`: emits a warning when the URL is `http://`:
- JSON mode: `{"warning": "Connecting over HTTP..."}` on stdout before prompts
- Human mode: `⚠️ Warning: connecting over HTTP...` in yellow

Does not block (localhost/internal use is valid).

---

## 🟡 MEDIUM #3 — Push token path traversal

`heartbeat.ts`: validate push token with `/^[a-zA-Z0-9_-]+$/` before constructing URL.

```bash
kuma heartbeat send '../../etc/passwd' --json
# { "ok": false, "error": "Invalid push token format...", "code": 1 }
```

---

## 🟡 MEDIUM #5 — Upgrade installs `@latest` (supply chain risk)

`upgrade.ts`: now installs the exact version confirmed from GitHub Releases:
`npm install -g @blackasteroid/kuma-cli@X.Y.Z` instead of `@latest`.

---

## 🔵 LOW #6 — No SECURITY.md

Added `.github/SECURITY.md`:
- Private disclosure email: security@blackasteroid.com.ar
- 48h acknowledgement / 7-day fix SLA
- Known security considerations (token storage, secret handling, HTTPS, upgrade, push tokens)

---

## 🔵 LOW #7 — parseInt without positive validation

`heartbeat view` and `notifications delete`: now validate that IDs are positive integers (> 0). `heartbeat view 0` and `notifications delete -1` return clear errors.

---

## Out of scope (documented in SECURITY.md)
- **#4 OS keychain** — high effort, planned for future sprint