### PR TITLE
feat: add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,55 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+
+      - name: Update Homebrew Tap
+        if: success()
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          # Get the new version released by semantic-release
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "Updating homebrew-tap formula for kuma-cli v${NEW_VERSION}"
+
+          # Download the tarball and compute SHA256
+          TGZ_URL="https://registry.npmjs.org/@blackasteroid/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
+          curl -sL "$TGZ_URL" -o /tmp/kuma-cli.tgz
+          SHA256=$(sha256sum /tmp/kuma-cli.tgz | awk '{print $1}')
+          echo "SHA256: $SHA256"
+
+          # Clone the tap repo
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/BlackAsteroid/homebrew-tap.git" /tmp/homebrew-tap
+          cd /tmp/homebrew-tap
+
+          git config user.email "dante@blackasteroid.com.ar"
+          git config user.name "Dante (DevOps) [bot]"
+
+          # Update the formula
+          cat > Formula/kuma-cli.rb << FORMULA
+          class KumaCli < Formula
+            desc "CLI for managing Uptime Kuma via its native Socket.IO API"
+            homepage "https://github.com/BlackAsteroid/kuma-cli"
+            url "https://registry.npmjs.org/@blackasteroid/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
+            sha256 "${SHA256}"
+            license "MIT"
+            version "${NEW_VERSION}"
+
+            depends_on "node"
+
+            def install
+              system "npm", "install", *std_npm_args
+              bin.install_symlink Dir["#{libexec}/bin/*"]
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/kuma --version")
+            end
+          end
+          FORMULA
+
+          # Fix indentation (heredoc added leading spaces)
+          sed -i 's/^          //' Formula/kuma-cli.rb
+
+          git add Formula/kuma-cli.rb
+          git diff --cached --quiet || git commit -m "chore: bump kuma-cli to v${NEW_VERSION}"
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 ## Install
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew tap BlackAsteroid/tap
+brew install kuma-cli
+```
+
+### npm
+
 ```bash
 npm install -g @blackasteroid/kuma-cli
 ```


### PR DESCRIPTION
## Summary

Adds support for installing `kuma-cli` via Homebrew, using the [BlackAsteroid/homebrew-tap](https://github.com/BlackAsteroid/homebrew-tap).

## Changes

### README.md
- Added **Homebrew** as the primary installation method
- npm remains as alternative

### .github/workflows/release.yml
- Added `Update Homebrew Tap` step after semantic-release
- On every release, the step:
  1. Reads the new version from `package.json`
  2. Downloads the npm tarball and computes SHA256
  3. Clones `BlackAsteroid/homebrew-tap`
  4. Updates `Formula/kuma-cli.rb` with new version + SHA256
  5. Commits and pushes to the tap repo
- Uses `HOMEBREW_TAP_TOKEN` secret (already set on this repo)

## Usage (post-merge)

```bash
brew tap BlackAsteroid/tap
brew install kuma-cli
```