### PR TITLE
chore: rename org from blackasteroid to pablofmorales

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in kuma-cli, **do not open a public Git
 
 Please report it privately:
 
-- **Email:** security@blackasteroid.com.ar
+- **Email:** pablofmorales@gmail.com
 - **Response time:** We aim to acknowledge within 48 hours and provide a fix or mitigation within 7 days for critical issues.
 
 Include:
@@ -22,7 +22,7 @@ We will credit you in the release notes unless you prefer to remain anonymous.
 Only the latest published version on npm is actively supported. Please update before reporting.
 
 ```bash
-npm install -g @blackasteroid/kuma-cli@latest
+npm install -g @pablofmorales/kuma-cli@latest
 ```
 
 ## Known Security Considerations
@@ -54,4 +54,4 @@ npm install -g @blackasteroid/kuma-cli@latest
 
 ### Upgrade integrity
 
-- `kuma upgrade` installs the specific version confirmed from GitHub Releases (e.g., `@blackasteroid/kuma-cli@1.2.0`) rather than `@latest` to reduce exposure to supply chain attacks on the npm registry.
+- `kuma upgrade` installs the specific version confirmed from GitHub Releases (e.g., `@pablofmorales/kuma-cli@1.2.0`) rather than `@latest` to reduce exposure to supply chain attacks on the npm registry.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout pr-review-agents
         uses: actions/checkout@v4
         with:
-          repository: blackasteroid/pr-review-agents
+          repository: pablofmorales/pr-review-agents
           token: ${{ secrets.GH_PAT }}
           path: .pr-review-agents
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Updating homebrew-tap formula for kuma-cli v${NEW_VERSION}"
 
           # Download the tarball and compute SHA256
-          TGZ_URL="https://registry.npmjs.org/@blackasteroid/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
+          TGZ_URL="https://registry.npmjs.org/@pablofmorales/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
           curl -sL "$TGZ_URL" -o /tmp/kuma-cli.tgz
           SHA256=$(sha256sum /tmp/kuma-cli.tgz | awk '{print $1}')
           echo "SHA256: $SHA256"
@@ -62,7 +62,7 @@ jobs:
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/pablofmorales/homebrew-tap.git" /tmp/homebrew-tap
           cd /tmp/homebrew-tap
 
-          git config user.email "dante@blackasteroid.com.ar"
+          git config user.email "pablofmorales@gmail.com"
           git config user.name "Dante (DevOps) [bot]"
 
           # Update the formula
@@ -70,7 +70,7 @@ jobs:
           class KumaCli < Formula
             desc "CLI for managing Uptime Kuma via its native Socket.IO API"
             homepage "https://github.com/pablofmorales/kuma-cli"
-            url "https://registry.npmjs.org/@blackasteroid/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
+            url "https://registry.npmjs.org/@pablofmorales/kuma-cli/-/kuma-cli-${NEW_VERSION}.tgz"
             sha256 "${SHA256}"
             license "MIT"
             version "${NEW_VERSION}"

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ brew install kuma-cli
 ### npm
 
 ```bash
-npm install -g @blackasteroid/kuma-cli
+npm install -g @pablofmorales/kuma-cli
 ```
 
 Or use without installing:
 
 ```bash
-npx @blackasteroid/kuma-cli login https://kuma.example.com
+npx @pablofmorales/kuma-cli login https://kuma.example.com
 ```
 
 ## Quick start
@@ -343,4 +343,4 @@ src/
 
 ## License
 
-MIT — [Black Asteroid](https://blackasteroid.com.ar)
+MIT — [pablofmorales](https://github.com/pablofmorales)

--- a/docs/plans/2026-03-29-multi-instance-cluster-design.md
+++ b/docs/plans/2026-03-29-multi-instance-cluster-design.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Existing stack (TypeScript, Commander.js, Socket.IO, conf library). No new dependencies required.
 
-**Tracking:** https://github.com/BlackAsteroid/kuma-cli/issues/59
+**Tracking:** https://github.com/pablofmorales/kuma-cli/issues/59
 
 ---
 

--- a/docs/plans/2026-03-29-multi-instance-cluster-plan.md
+++ b/docs/plans/2026-03-29-multi-instance-cluster-plan.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** TypeScript, Commander.js, Socket.IO, conf library, Vitest (new, for testing).
 
-**Tracking:** https://github.com/BlackAsteroid/kuma-cli/issues/59
+**Tracking:** https://github.com/pablofmorales/kuma-cli/issues/59
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@blackasteroid/kuma-cli",
+  "name": "@pablofmorales/kuma-cli",
   "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@blackasteroid/kuma-cli",
+      "name": "@pablofmorales/kuma-cli",
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blackasteroid/kuma-cli",
+  "name": "@pablofmorales/kuma-cli",
   "version": "1.5.0",
   "description": "CLI for managing Uptime Kuma via Socket.IO API",
   "bin": {
@@ -21,7 +21,7 @@
     "cli",
     "monitoring"
   ],
-  "author": "Black Asteroid",
+  "author": "Pablo Morales",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -1,5 +1,5 @@
 /**
- * semantic-release configuration for @blackasteroid/kuma-cli
+ * semantic-release configuration for @pablofmorales/kuma-cli
  *
  * Versioning rules:
  *   feat:               → minor (0.X.0)

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -143,7 +143,7 @@ ${chalk.dim("Examples:")}
         // instead of "latest" to reduce supply-chain attack surface.
         // If the npm registry were compromised between the GitHub check and this
         // install, a pinned version installs the exact artifact we verified.
-        execSync(`npm install -g @blackasteroid/kuma-cli@${latest}`, {
+        execSync(`npm install -g @pablofmorales/kuma-cli@${latest}`, {
           stdio: json ? "pipe" : "inherit",
         });
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- Renamed all references from `@blackasteroid`/`BlackAsteroid` org to `@pablofmorales` across the repo
- Updated npm scope in `package.json`, `upgrade.ts`, `release.config.cjs`, `SECURITY.md`, and `README.md`
- Updated GitHub org references in workflow files (`release.yml`, `pr-review.yml`) and design docs
- Updated author field in `package.json` and license attribution in `README.md`
- Regenerated `package-lock.json` via `npm install`

Skipped: `CHANGELOG.md` (auto-generated), `dist/` (build output), and `--tag BlackAsteroid` in `monitors.ts` (user-facing example, not an org reference).

## Test plan
- [ ] Verify `npm install` succeeds with the new scope
- [ ] Verify `npm run build` produces a working `dist/index.js`
- [ ] Verify `kuma upgrade` references the correct `@pablofmorales/kuma-cli` package
- [ ] Verify the release workflow TGZ_URL points to the correct npm registry path
- [ ] Grep for any remaining `blackasteroid` references (expect only CHANGELOG.md, dist/, and the example tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)