### PR TITLE
feat: migrate config storage to ~/.config/kuma-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chalk": "^5.6.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
-        "conf": "^15.1.0",
         "enquirer": "^2.4.1",
         "js-yaml": "^4.1.1",
         "socket.io-client": "^4.8.3"
@@ -2259,39 +2258,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -2374,16 +2340,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/atomically": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
-      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-fs": "^2.0.0",
-        "when-exit": "^2.1.4"
       }
     },
     "node_modules/before-after-hook": {
@@ -2758,29 +2714,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/conf": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-15.1.0.tgz",
-      "integrity": "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "atomically": "^2.0.3",
-        "debounce-fn": "^6.0.0",
-        "dot-prop": "^10.0.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.7.2",
-        "uint8array-extras": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
@@ -3009,21 +2942,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/debounce-fn": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-6.0.0.tgz",
-      "integrity": "sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3072,21 +2990,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
-      "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/duplexer2": {
@@ -3292,18 +3195,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -3462,28 +3353,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4084,18 +3953,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/json-with-bigint": {
       "version": "3.5.7",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.7.tgz",
@@ -4670,18 +4527,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimist": {
@@ -7318,15 +7163,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -7552,6 +7388,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7930,21 +7767,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stubborn-fs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
-      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
-      "license": "MIT",
-      "dependencies": {
-        "stubborn-utils": "^1.0.1"
-      }
-    },
-    "node_modules/stubborn-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
-      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
-      "license": "MIT"
-    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -8030,6 +7852,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8302,6 +8125,7 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
       "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -8346,18 +8170,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici": {
@@ -8637,12 +8449,6 @@
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
-      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
-    "conf": "^15.1.0",
     "enquirer": "^2.4.1",
     "js-yaml": "^4.1.1",
     "socket.io-client": "^4.8.3"

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { migrateConfig, deriveInstanceName } from "../config.js";
+import { migrateConfig, deriveInstanceName, getConfigDir, migrateConfigPath } from "../config.js";
+import * as os from "os";
+import * as path from "path";
 
 describe("config migration", () => {
   it("migrates old {url, token} to new schema", () => {
@@ -44,5 +46,44 @@ describe("config migration", () => {
     expect(deriveInstanceName("https://kuma.prod.example.com")).toBe("kuma-prod-example-com");
     expect(deriveInstanceName("https://192.168.1.1:3001")).toBe("192-168-1-1-3001");
     expect(deriveInstanceName("http://localhost:3001")).toBe("localhost-3001");
+  });
+});
+
+describe("config path", () => {
+  it("returns ~/.config/kuma-cli as config directory", () => {
+    const dir = getConfigDir();
+    expect(dir).toBe(path.join(os.homedir(), ".config", "kuma-cli"));
+  });
+});
+
+describe("config path migration", () => {
+  it("returns old config data when old path exists and new path does not", () => {
+    // migrateConfigPath is a pure function:
+    //   (oldPath: string | null, newPath: string | null) => { source: "old" | "new" | "none", data: object | null }
+    const oldData = { instances: { prod: { url: "https://kuma.example.com", token: "abc" } }, clusters: {}, active: null };
+    const result = migrateConfigPath(JSON.stringify(oldData), null);
+    expect(result.source).toBe("old");
+    expect(result.data).toEqual(oldData);
+  });
+
+  it("returns new config data when new path exists", () => {
+    const newData = { instances: { staging: { url: "https://staging.example.com", token: "def" } }, clusters: {}, active: null };
+    const result = migrateConfigPath(null, JSON.stringify(newData));
+    expect(result.source).toBe("new");
+    expect(result.data).toEqual(newData);
+  });
+
+  it("prefers new path over old path", () => {
+    const oldData = { instances: { old: { url: "https://old.example.com", token: "old" } }, clusters: {}, active: null };
+    const newData = { instances: { new: { url: "https://new.example.com", token: "new" } }, clusters: {}, active: null };
+    const result = migrateConfigPath(JSON.stringify(oldData), JSON.stringify(newData));
+    expect(result.source).toBe("new");
+    expect(result.data).toEqual(newData);
+  });
+
+  it("returns none when neither path has data", () => {
+    const result = migrateConfigPath(null, null);
+    expect(result.source).toBe("none");
+    expect(result.data).toBeNull();
   });
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -50,9 +50,43 @@ describe("config migration", () => {
 });
 
 describe("config path", () => {
-  it("returns ~/.config/kuma-cli as config directory", () => {
-    const dir = getConfigDir();
-    expect(dir).toBe(path.join(os.homedir(), ".config", "kuma-cli"));
+  it("respects XDG_CONFIG_HOME on non-Windows platforms", () => {
+    if (process.platform === "win32") return;
+
+    const originalXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = "/tmp/custom-config";
+    try {
+      const dir = getConfigDir();
+      expect(dir).toBe(path.join("/tmp/custom-config", "kuma-cli"));
+    } finally {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+  });
+
+  it("returns default path if XDG_CONFIG_HOME is not set", () => {
+    if (process.platform === "win32") return;
+
+    const originalXdg = process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_CONFIG_HOME;
+    try {
+      const dir = getConfigDir();
+      expect(dir).toBe(path.join(os.homedir(), ".config", "kuma-cli"));
+    } finally {
+      process.env.XDG_CONFIG_HOME = originalXdg;
+    }
+  });
+
+  it("uses APPDATA on Windows", () => {
+    if (process.platform !== "win32") return;
+
+    const originalAppdata = process.env.APPDATA;
+    process.env.APPDATA = "C:\\Users\\Test\\AppData\\Roaming";
+    try {
+      const dir = getConfigDir();
+      expect(dir).toBe(path.join("C:\\Users\\Test\\AppData\\Roaming", "kuma-cli"));
+    } finally {
+      process.env.APPDATA = originalAppdata;
+    }
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
-import Conf from "conf";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
 
 // --- Interfaces ---
 
@@ -23,11 +25,72 @@ export interface KumaConfigSchema {
   active: ActiveContext | null;
 }
 
-// --- Conf store (schemaless to support migration) ---
+// --- Config path ---
 
-const conf = new Conf<Record<string, unknown>>({
-  projectName: "kuma-cli",
-});
+export function getConfigDir(): string {
+  return path.join(os.homedir(), ".config", "kuma-cli");
+}
+
+function getConfigFilePath(): string {
+  return path.join(getConfigDir(), "config.json");
+}
+
+/**
+ * Returns the old platform-specific config path used by the `conf` library.
+ * macOS: ~/Library/Preferences/kuma-cli-nodejs/config.json
+ * Linux: ~/.config/kuma-cli-nodejs/config.json
+ * Windows: %APPDATA%/kuma-cli-nodejs/config.json
+ */
+function getOldConfigFilePath(): string {
+  const platform = process.platform;
+  if (platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Preferences", "kuma-cli-nodejs", "config.json");
+  }
+  if (platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), "kuma-cli-nodejs", "config.json");
+  }
+  // Linux and others: XDG
+  return path.join(process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"), "kuma-cli-nodejs", "config.json");
+}
+
+/**
+ * Pure function to decide which config source to use.
+ * Inputs are file contents as strings (null if file doesn't exist).
+ */
+export function migrateConfigPath(
+  oldContent: string | null,
+  newContent: string | null
+): { source: "old" | "new" | "none"; data: Record<string, unknown> | null } {
+  if (newContent !== null) {
+    try {
+      return { source: "new", data: JSON.parse(newContent) };
+    } catch {
+      // Corrupted new config — fall through
+    }
+  }
+  if (oldContent !== null) {
+    try {
+      return { source: "old", data: JSON.parse(oldContent) };
+    } catch {
+      // Corrupted old config — fall through
+    }
+  }
+  return { source: "none", data: null };
+}
+
+function readFileOrNull(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function writeConfigFile(data: Record<string, unknown>): void {
+  const filePath = getConfigFilePath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+}
 
 // --- Hostname derivation ---
 
@@ -83,16 +146,26 @@ export function migrateConfig(raw: Record<string, unknown>): KumaConfigSchema {
 // --- Internal: load and save full config ---
 
 function loadConfig(): KumaConfigSchema {
-  const raw = conf.store;
-  const migrated = migrateConfig(raw as Record<string, unknown>);
-  if (!raw.instances) {
-    conf.store = migrated as unknown as Record<string, unknown>;
+  const newPath = getConfigFilePath();
+  const oldPath = getOldConfigFilePath();
+  const { source, data } = migrateConfigPath(readFileOrNull(oldPath), readFileOrNull(newPath));
+
+  if (source === "none" || data === null) {
+    return { instances: {}, clusters: {}, active: null };
   }
+
+  const migrated = migrateConfig(data);
+
+  // Persist to new location if read from old path or if schema migration happened
+  if (source === "old" || !data.instances) {
+    writeConfigFile(migrated as unknown as Record<string, unknown>);
+  }
+
   return migrated;
 }
 
 function saveFullConfig(config: KumaConfigSchema): void {
-  conf.store = config as unknown as Record<string, unknown>;
+  writeConfigFile(config as unknown as Record<string, unknown>);
 }
 
 // --- Public API: Instances ---
@@ -225,9 +298,14 @@ export function saveConfig(instanceConfig: { url: string; token: string }, alias
 }
 
 export function clearConfig(): void {
-  conf.clear();
+  const filePath = getConfigFilePath();
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // File doesn't exist — nothing to clear
+  }
 }
 
 export function getConfigPath(): string {
-  return conf.path;
+  return getConfigFilePath();
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,12 @@ export interface KumaConfigSchema {
 // --- Config path ---
 
 export function getConfigDir(): string {
-  return path.join(os.homedir(), ".config", "kuma-cli");
+  const platform = process.platform;
+  if (platform === "win32") {
+    return path.join(process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming"), "kuma-cli");
+  }
+  const configHome = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  return path.join(configHome, "kuma-cli");
 }
 
 function getConfigFilePath(): string {
@@ -88,8 +93,16 @@ function readFileOrNull(filePath: string): string | null {
 
 function writeConfigFile(data: Record<string, unknown>): void {
   const filePath = getConfigFilePath();
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), "utf-8");
+  const dirPath = path.dirname(filePath);
+
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
 // --- Hostname derivation ---


### PR DESCRIPTION
Move config storage from the conf library's platform-specific path to a fixed ~/.config/kuma-cli/config.json and drop the conf dependency.

Architecture: Replace Conf store with direct fs read/write to ~/.config/kuma-cli/config.json. On first run, auto-migrates data from the old platform-specific path.

Fixes #61