### PR TITLE
fix: send accepted_statuscodes as array instead of pre-stringified JSON

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -133,7 +133,7 @@ var KumaClient = class {
   async addMonitor(monitor) {
     const autoToken = monitor.type === "push" && !monitor.pushToken ? Array.from(crypto.getRandomValues(new Uint8Array(24))).map((b) => b.toString(16).padStart(2, "0")).join("") : void 0;
     const payload = {
-      accepted_statuscodes_json: JSON.stringify(["200-299"]),
+      accepted_statuscodes: ["200-299"],
       maxretries: 1,
       retryInterval: 60,
       conditions: [],

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+
+// Hoist mock factories before any imports
+const { mockEmit, mockOn, mockOnce, mockDisconnect, mockIo } = vi.hoisted(() => ({
+  mockEmit: vi.fn(),
+  mockOn: vi.fn(),
+  mockOnce: vi.fn(),
+  mockDisconnect: vi.fn(),
+  mockIo: vi.fn(),
+}));
+
+// Mock socket.io-client — io() returns our mock socket
+vi.mock("socket.io-client", () => ({
+  io: mockIo,
+}));
+
+import { KumaClient } from "../client.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Return a minimal socket stub
+  mockIo.mockReturnValue({
+    on: mockOn,
+    once: mockOnce,
+    emit: mockEmit,
+    disconnect: mockDisconnect,
+    io: { opts: { reconnection: false } },
+  });
+});
+
+describe("KumaClient.addMonitor", () => {
+  it("sends accepted_statuscodes as an array, not a string", () => {
+    const client = new KumaClient("http://dummy:3000");
+
+    // Call addMonitor (it will try to connect, but the mock socket won't actually connect)
+    // The method returns a promise that times out after 10s, so we catch the rejection.
+    // We're only testing the synchronous part: payload construction before emit.
+    client.addMonitor({
+      name: "test",
+      type: "http",
+      url: "http://example.com",
+      interval: 60,
+    });
+
+    // Verify the "add" event was emitted with the correct payload
+    expect(mockEmit).toHaveBeenCalled();
+    const emitCall = mockEmit.mock.calls.find((call: unknown[]) => call[0] === "add");
+    expect(emitCall).toBeDefined();
+    const payload: Record<string, unknown> = emitCall![1] as Record<string, unknown>;
+
+    // accepted_statuscodes must be an array
+    expect(Array.isArray(payload.accepted_statuscodes)).toBe(true);
+
+    // Must contain expected status range
+    expect(payload.accepted_statuscodes).toContain("200-299");
+
+    // Must NOT use the DB column name (pre-stringified form)
+    expect(payload).not.toHaveProperty("accepted_statuscodes_json");
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -245,7 +245,7 @@ export class KumaClient {
         : undefined;
 
     const payload = {
-      accepted_statuscodes_json: JSON.stringify(["200-299"]),
+      accepted_statuscodes: ["200-299"],
       maxretries: 1,
       retryInterval: 60,
       conditions: [],


### PR DESCRIPTION
# Bug Report

## Description

`kuma monitors add` and `kuma monitors create` fail with "Cannot read properties of undefined (reading 'every')" on every invocation. The root cause is a field name mismatch: kuma-cli sends `accepted_statuscodes_json` (pre-stringified) but Uptime Kuma's socket handler expects `accepted_statuscodes` as a raw array.

## Steps to Reproduce

1. Login to a running Uptime Kuma instance: `kuma login http://<host>:<port>`
2. Attempt to add a monitor:

```
kuma monitors add --name "Test" --type http --url http://example.com
```

1. Observe error:

```
❌ Cannot read properties of undefined (reading 'every')
```

Same error with `kuma monitors create`:

```
kuma monitors create --name "Test" --type http --url http://example.com
```

## Expected Behavior

Monitor is created successfully. The `accepted_statuscodes` field is sent as a raw array matching what Uptime Kuma's socket handler expects.

## Error Output

```
❌ Cannot read properties of undefined (reading 'every')
```

With `--json`:

```json
{
  "ok": false,
  "error": "Cannot read properties of undefined (reading 'every')",
  "code": 1
}
```

## Root Cause

Field name mismatch in `addMonitor` (`src/client.ts:248`).

kuma-cli sends:

```typescript
accepted_statuscodes_json: JSON.stringify(["200-299"]),
```

Uptime Kuma's `add` socket handler (`server/server.js` lines 751–756) expects `accepted_statuscodes` as a raw array, then stringifies it internally:

```javascript
// Expects accepted_statuscodes to be an array of strings
if (!monitor.accepted_statuscodes.every((code) => typeof code === "string")) {
    throw new Error("Accepted status codes are not all strings");
}
monitor.accepted_statuscodes_json = JSON.stringify(monitor.accepted_statuscodes);
delete monitor.accepted_statuscodes;
```

Because kuma-cli sends `accepted_statuscodes_json` (the DB column name) instead of `accepted_statuscodes` (the frontend property name), the server reads `undefined`, and `undefined.every(...)` throws.

The `editMonitor` socket handler (line 843) has the same check, so `kuma monitors update` and notification assignment via `setMonitorNotification` are also affected.

## History

- Commit `de00991` originally had the correct payload (`accepted_statuscodes: ["200-299"]`).
- Commit `74ca6be` changed it to `accepted_statuscodes_json: JSON.stringify(["200-299"])` — likely confusion between the DB column name (`accepted_statuscodes_json`) and the socket wire format (`accepted_statuscodes` as raw array).
- Commit `2eb42e3` attempted to send both fields but was never merged to main.
- The bug has been present since v1.7.0 (released 2026-04-02).

## Environment

- kuma-cli version: 1.7.0
- Uptime Kuma version: 2.4.0
- Platform: Windows 11

## Reproduced using

```
kuma status               ✓ works
kuma monitors list        ✓ works
kuma monitors add         ✗ fails
kuma monitors create      ✗ fails
kuma monitors update      ✗ fails (same root cause in editMonitor)
```

*** This was diagnosed and checked with the help of AI ***