### PR TITLE
feat: add keyword monitor type support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1070,7 +1070,8 @@ var MONITOR_TYPES = [
   "mongodb",
   "radius",
   "redis",
-  "group"
+  "group",
+  "keyword"
 ];
 function monitorsCommand(program2) {
   const monitors = program2.command("monitors").description("Create, view, update, pause, resume, and delete monitors").addHelpText(
@@ -1288,7 +1289,7 @@ ${list.length} monitor(s) total`);
       }
     }
   );
-  monitors.command("add").description("Add a new monitor \u2014 runs interactively if flags are omitted").option("--name <name>", "Display name for the monitor").option("--type <type>", "Monitor type: http, tcp, ping, dns, push, steam, ...").option("--url <url>", "URL (http), hostname:port (tcp), or hostname (ping/dns)").option("--interval <seconds>", "How often to check, in seconds (default: 60)", "60").option("--json", "Output as JSON ({ ok, data })").option("--instance <name>", "Target a specific instance").option("--parent <id>", "Add as a child monitor under an existing group monitor (ID)").addHelpText(
+  monitors.command("add").description("Add a new monitor \u2014 runs interactively if flags are omitted").option("--name <name>", "Display name for the monitor").option("--type <type>", "Monitor type: http, tcp, ping, dns, push, steam, ...").option("--url <url>", "URL (http), hostname:port (tcp), or hostname (ping/dns)").option("--interval <seconds>", "How often to check, in seconds (default: 60)", "60").option("--json", "Output as JSON ({ ok, data })").option("--instance <name>", "Target a specific instance").option("--parent <id>", "Add as a child monitor under an existing group monitor (ID)").option("--keyword <keyword>", "Keyword to search for in response body (for type: keyword)").addHelpText(
     "after",
     `
 ${chalk4.dim("Examples:")}
@@ -1332,19 +1333,20 @@ ${chalk4.dim("Examples:")}
           type,
           url,
           interval,
+          keyword: opts.keyword,
           parent: opts.parent ? parseInt(opts.parent, 10) : void 0
         });
-        client.disconnect();
         if (json) {
-          jsonOut({ id: result.id, name, type, url, interval });
+          jsonOut({ id: result.id, name, type, url, keyword: opts.keyword, interval });
         }
+        client.disconnect();
         success(`Monitor "${name}" created (ID: ${result.id})`);
       } catch (err) {
         handleError(err, opts);
       }
     }
   );
-  monitors.command("create").description("Create a monitor non-interactively \u2014 designed for CI/CD pipelines").requiredOption("--name <name>", "Monitor display name").requiredOption("--type <type>", "Monitor type: http, tcp, ping, dns, push, ...").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds (default: 60)", "60").option("--tag <tag>", "Assign a tag by name (repeatable \u2014 must already exist in Kuma)", collect, []).option("--notification-id <id>", "Assign a notification channel by ID (repeatable)", collectInt, []).option("--json", "Output as JSON ({ ok, data }) \u2014 prints monitor ID and pushToken to stdout").option("--instance <name>", "Target a specific instance").option("--parent <id>", "Create as a child monitor under an existing group monitor (ID)").addHelpText(
+  monitors.command("create").description("Create a monitor non-interactively \u2014 designed for CI/CD pipelines").requiredOption("--name <name>", "Monitor display name").requiredOption("--type <type>", "Monitor type: http, tcp, ping, dns, push, ...").option("--url <url>", "URL or hostname to monitor").option("--interval <seconds>", "Check interval in seconds (default: 60)", "60").option("--tag <tag>", "Assign a tag by name (repeatable \u2014 must already exist in Kuma)", collect, []).option("--notification-id <id>", "Assign a notification channel by ID (repeatable)", collectInt, []).option("--json", "Output as JSON ({ ok, data }) \u2014 prints monitor ID and pushToken to stdout").option("--instance <name>", "Target a specific instance").option("--parent <id>", "Create as a child monitor under an existing group monitor (ID)").option("--keyword <keyword>", "Keyword to search for in response body (for type: keyword)").addHelpText(
     "after",
     `
 ${chalk4.dim("Examples:")}
@@ -1371,6 +1373,7 @@ ${chalk4.dim("Full pipeline (deploy \u2192 monitor \u2192 heartbeat):")}
         type: opts.type,
         url: opts.url,
         interval,
+        keyword: opts.keyword,
         parent: opts.parent ? parseInt(opts.parent, 10) : void 0
       });
       const monitorId = result.id;
@@ -1405,6 +1408,7 @@ ${chalk4.dim("Full pipeline (deploy \u2192 monitor \u2192 heartbeat):")}
           name: opts.name,
           type: opts.type,
           url: opts.url ?? null,
+          keyword: opts.keyword,
           interval
         };
         if (pushToken) data.pushToken = pushToken;

--- a/src/__tests__/monitors.test.ts
+++ b/src/__tests__/monitors.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import { monitorsCommand } from "../commands/monitors.js";
+
+describe("monitors add command", () => {
+  it("accepts --keyword option", () => {
+    const program = new Command();
+    monitorsCommand(program);
+
+    const monitors = program.commands.find((c) => c.name() === "monitors");
+    expect(monitors).toBeDefined();
+
+    const addCmd = monitors!.commands.find((c) => c.name() === "add");
+    expect(addCmd).toBeDefined();
+
+    const optionNames = addCmd!.options.map((o) => o.name());
+    expect(optionNames).toContain("keyword");
+  });
+});
+
+describe("monitors create command", () => {
+  it("accepts --keyword option", () => {
+    const program = new Command();
+    monitorsCommand(program);
+
+    const monitors = program.commands.find((c) => c.name() === "monitors");
+    expect(monitors).toBeDefined();
+
+    const createCmd = monitors!.commands.find((c) => c.name() === "create");
+    expect(createCmd).toBeDefined();
+
+    const optionNames = createCmd!.options.map((o) => o.name());
+    expect(optionNames).toContain("keyword");
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,8 @@ export interface Monitor {
   active: boolean;
   uptime?: number;
   tags?: MonitorTag[];
+  keyword?: string;
+  invertKeyword?: boolean;
   notificationIDList?: Record<string, boolean>;
   parent?: number;
   heartbeat?: {

--- a/src/commands/monitors.ts
+++ b/src/commands/monitors.ts
@@ -43,7 +43,8 @@ const MONITOR_TYPES = [
   "mongodb",
   "radius",
   "redis",
-  "group"
+  "group",
+  "keyword",
 ];
 
 export function monitorsCommand(program: Command): void {
@@ -357,6 +358,7 @@ ${chalk.dim("Examples:")}
     .option("--json", "Output as JSON ({ ok, data })")
     .option("--instance <name>", "Target a specific instance")
     .option("--parent <id>", "Add as a child monitor under an existing group monitor (ID)")
+    .option("--keyword <keyword>", "Keyword to search for in response body (for type: keyword)")
     .addHelpText(
       "after",
       `
@@ -372,6 +374,7 @@ ${chalk.dim("Examples:")}
         name?: string;
         type?: string;
         url?: string;
+        keyword?: string;
         interval?: string;
         json?: boolean;
         instance?: string;
@@ -417,13 +420,14 @@ ${chalk.dim("Examples:")}
             type, 
             url, 
             interval, 
+            keyword: opts.keyword,
             parent: opts.parent ? parseInt(opts.parent, 10) : undefined 
           });
-          client.disconnect();
 
           if (json) {
-            jsonOut({ id: result.id, name, type, url, interval });
+            jsonOut({ id: result.id, name, type, url, keyword: opts.keyword, interval });
           }
+          client.disconnect();
 
           success(`Monitor "${name}" created (ID: ${result.id})`);
         } catch (err) {
@@ -431,7 +435,6 @@ ${chalk.dim("Examples:")}
         }
       }
     );
-
   // CREATE (non-interactive, with tag support — for CI/CD pipelines)
   monitors
     .command("create")
@@ -445,6 +448,7 @@ ${chalk.dim("Examples:")}
     .option("--json", "Output as JSON ({ ok, data }) — prints monitor ID and pushToken to stdout")
     .option("--instance <name>", "Target a specific instance")
     .option("--parent <id>", "Create as a child monitor under an existing group monitor (ID)")
+    .option("--keyword <keyword>", "Keyword to search for in response body (for type: keyword)")
     .addHelpText(
       "after",
       `
@@ -464,6 +468,7 @@ ${chalk.dim("Full pipeline (deploy → monitor → heartbeat):")}
       name: string;
       type: string;
       url?: string;
+      keyword?: string;
       interval?: string;
       tag: string[];
       notificationId: number[];
@@ -488,6 +493,7 @@ ${chalk.dim("Full pipeline (deploy → monitor → heartbeat):")}
           type: opts.type,
           url: opts.url,
           interval,
+          keyword: opts.keyword,
           parent: opts.parent ? parseInt(opts.parent, 10) : undefined,
         });
         const monitorId = result.id;
@@ -533,6 +539,7 @@ ${chalk.dim("Full pipeline (deploy → monitor → heartbeat):")}
             name: opts.name,
             type: opts.type,
             url: opts.url ?? null,
+            keyword: opts.keyword,
             interval,
           };
           if (pushToken) data.pushToken = pushToken;


### PR DESCRIPTION
# Feature Request

## Description

Add keyword-type monitor support to `kuma monitors add` and `kuma monitors create`. Uptime Kuma supports keyword monitors (response body text matching), available in the web UI as type "keyword", but kuma-cli excludes this type from its type list and offers no `--keyword` flag.

## Current Behavior

- `MONITOR_TYPES` array in `src/commands/monitors.ts` excludes `"keyword"`, so the interactive prompt doesn't offer it and the type alias is not recognized.
- Neither `monitors add` nor `monitors create` accept a `--keyword` flag or pass `keyword`/`invertKeyword` fields to the server.
- The `Monitor` interface in `src/client.ts` has no `keyword` or `invertKeyword` properties, so TypeScript rejects any attempt to pass them.

## Expected Behavior

- `"keyword"` is a selectable type in `MONITOR_TYPES`.
- Both `monitors add` and `monitors create` accept `--keyword <value>` to set the keyword to match in the response body.
- When `--type keyword` is used, the keyword value is passed to `addMonitor()` and included in JSON output.
- The `Monitor` interface includes optional `keyword` and `invertKeyword` fields for type safety.

## Example Usage

```
kuma monitors add --name "Health Check" --type keyword --url http://example.com/health --keyword "UP"

kuma monitors create --name "Health Check" --type keyword --url http://example.com/health --keyword "UP" --notification-id 1 --json
```

## Implementation Notes

- `"keyword"` added to `MONITOR_TYPES` array.
- `--keyword <keyword>` option added to `monitors add` (CLI flags) and `monitors create` (CI/CD).
- `keyword: opts.keyword` passed to `client.addMonitor()`.
- `keyword` field included in JSON output payload.
- `keyword?: string` and `invertKeyword?: boolean` added to `Monitor` interface in `src/client.ts`.

## Environment

- kuma-cli version: 1.7.0
- Uptime Kuma version: 2.4.0 (supports keyword type natively)

***This was diagnosed and checked with the help of AI***
